### PR TITLE
Add offline export/import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 4
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -229,9 +229,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -917,6 +917,7 @@ name = "espanso"
 version = "2.3.0"
 dependencies = [
  "anyhow",
+ "base64 0.21.7",
  "caps",
  "clap",
  "colored",
@@ -939,6 +940,7 @@ dependencies = [
  "espanso-package",
  "espanso-render",
  "espanso-ui",
+ "flate2",
  "fs2",
  "fs_extra",
  "libc",
@@ -954,8 +956,10 @@ dependencies = [
  "serde_norway",
  "simplelog",
  "sysinfo",
+ "tar",
  "tempdir",
  "thiserror 1.0.56",
+ "walkdir",
  "widestring",
  "windows",
  "winreg 0.9.0",
@@ -1222,13 +1226,11 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
@@ -1976,12 +1978,12 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
- "autocfg",
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2837,7 +2839,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2958,7 +2960,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3139,6 +3141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "simplelog"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,6 +3313,17 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4432,6 +4451,16 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.0.8",
 ]
 
 [[package]]

--- a/docs/src/ch04-02-recipes-and-cookbook.md
+++ b/docs/src/ch04-02-recipes-and-cookbook.md
@@ -342,3 +342,11 @@ The script saves the benchmark results to `results.md` and `results.json`.
 #### Benchmark script: analysing results
 The JSON output is more useful for statistical analysis. The hyperfine
 repository has [scripts for this purpose](https://github.com/sharkdp/hyperfine/tree/master/scripts).
+
+## Offline export/import
+
+Espanso can export its configuration as a base64 payload for air-gapped transfer
+using `espanso export` and restore it with `espanso import`.
+
+The `--convert-lb` flag is optional and only converts line breaks to LF for
+YAML files (`.yml`/`.yaml`) during import.

--- a/espanso-clipboard/src/cocoa/mod.rs
+++ b/espanso-clipboard/src/cocoa/mod.rs
@@ -26,7 +26,6 @@ use std::{
 
 use crate::{Clipboard, ClipboardOperationOptions};
 use anyhow::Result;
-use log::error;
 use std::os::raw::c_char;
 use thiserror::Error;
 

--- a/espanso-clipboard/src/win32/mod.rs
+++ b/espanso-clipboard/src/win32/mod.rs
@@ -23,7 +23,6 @@ use std::{ffi::CString, path::PathBuf};
 
 use crate::{Clipboard, ClipboardOperationOptions};
 use anyhow::Result;
-use log::error;
 use thiserror::Error;
 use widestring::{U16CStr, U16CString};
 

--- a/espanso-engine/src/dispatch/default.rs
+++ b/espanso-engine/src/dispatch/default.rs
@@ -18,7 +18,7 @@
  */
 
 use super::{
-    ContextMenuHandler, Event, IconHandler, ImageInjector, SecureInputManager, TextUIHandler,
+    ContextMenuHandler, Event, ExportImportHandler, IconHandler, ImageInjector, SecureInputManager, TextUIHandler,
 };
 use super::{Dispatcher, Executor, HtmlInjector, KeyInjector, ModeProvider, TextInjector};
 
@@ -39,6 +39,7 @@ impl<'a> DefaultDispatcher<'a> {
         icon_handler: &'a dyn IconHandler,
         secure_input_manager: &'a dyn SecureInputManager,
         text_ui_handler: &'a dyn TextUIHandler,
+        export_import_handler: &'a dyn ExportImportHandler,
     ) -> Self {
         Self {
             executors: vec![
@@ -67,6 +68,9 @@ impl<'a> DefaultDispatcher<'a> {
                 )),
                 Box::new(super::executor::text_ui::TextUIExecutor::new(
                     text_ui_handler,
+                )),
+                Box::new(super::executor::export_import::ExportImportExecutor::new(
+                    export_import_handler,
                 )),
             ],
         }

--- a/espanso-engine/src/dispatch/executor/export_import.rs
+++ b/espanso-engine/src/dispatch/executor/export_import.rs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::event::EventType;
+use crate::{dispatch::Executor, event::Event};
+use anyhow::Result;
+use log::error;
+
+pub trait ExportImportHandler {
+    fn handle_export(&self) -> Result<()>;
+    fn handle_import(&self) -> Result<()>;
+}
+
+pub struct ExportImportExecutor<'a> {
+    handler: &'a dyn ExportImportHandler,
+}
+
+impl<'a> ExportImportExecutor<'a> {
+    pub fn new(handler: &'a dyn ExportImportHandler) -> Self {
+        Self { handler }
+    }
+}
+
+impl Executor for ExportImportExecutor<'_> {
+    fn execute(&self, event: &Event) -> bool {
+        if matches!(&event.etype, EventType::ExportConfig) {
+            if let Err(error) = self.handler.handle_export() {
+                error!("export handler reported an error: {error:?}");
+            }
+            return true;
+        } else if matches!(&event.etype, EventType::ImportConfig) {
+            if let Err(error) = self.handler.handle_import() {
+                error!("import handler reported an error: {error:?}");
+            }
+            return true;
+        }
+
+        false
+    }
+}

--- a/espanso-engine/src/dispatch/executor/mod.rs
+++ b/espanso-engine/src/dispatch/executor/mod.rs
@@ -18,6 +18,7 @@
  */
 
 pub mod context_menu;
+pub mod export_import;
 pub mod html_inject;
 pub mod icon_update;
 pub mod image_inject;

--- a/espanso-engine/src/dispatch/mod.rs
+++ b/espanso-engine/src/dispatch/mod.rs
@@ -32,6 +32,7 @@ pub trait Dispatcher {
 
 // Re-export dependency injection entities
 pub use executor::context_menu::ContextMenuHandler;
+pub use executor::export_import::ExportImportHandler;
 pub use executor::html_inject::HtmlInjector;
 pub use executor::icon_update::IconHandler;
 pub use executor::image_inject::ImageInjector;
@@ -52,6 +53,7 @@ pub fn default<'a>(
     icon_handler: &'a dyn IconHandler,
     secure_input_manager: &'a dyn SecureInputManager,
     text_ui_handler: &'a dyn TextUIHandler,
+    export_import_handler: &'a dyn ExportImportHandler,
 ) -> impl Dispatcher + 'a {
     default::DefaultDispatcher::new(
         event_injector,
@@ -64,5 +66,6 @@ pub fn default<'a>(
         icon_handler,
         secure_input_manager,
         text_ui_handler,
+        export_import_handler,
     )
 }

--- a/espanso-engine/src/event/mod.rs
+++ b/espanso-engine/src/event/mod.rs
@@ -104,6 +104,8 @@ pub enum EventType {
     ShowSearchBar,
     ShowText(ui::ShowTextEvent),
     ShowLogs,
+    ExportConfig,
+    ImportConfig,
 
     // Other
     LaunchSecureInputAutoFix,

--- a/espanso-engine/src/process/middleware/context_menu.rs
+++ b/espanso-engine/src/process/middleware/context_menu.rs
@@ -34,6 +34,8 @@ const CONTEXT_ITEM_SECURE_INPUT_TRIGGER_WORKAROUND: u32 = 5;
 const CONTEXT_ITEM_OPEN_SEARCH: u32 = 6;
 const CONTEXT_ITEM_SHOW_LOGS: u32 = 7;
 const CONTEXT_ITEM_OPEN_CONFIG_FOLDER: u32 = 8;
+const CONTEXT_ITEM_EXPORT_CONFIG: u32 = 9;
+const CONTEXT_ITEM_IMPORT_CONFIG: u32 = 10;
 
 pub struct ContextMenuMiddleware {
     is_enabled: RefCell<bool>,
@@ -82,6 +84,14 @@ impl Middleware for ContextMenuMiddleware {
                     MenuItem::Simple(SimpleMenuItem {
                         id: CONTEXT_ITEM_RELOAD,
                         label: "Reload config".to_string(),
+                    }),
+                    MenuItem::Simple(SimpleMenuItem {
+                        id: CONTEXT_ITEM_EXPORT_CONFIG,
+                        label: "Export config".to_string(),
+                    }),
+                    MenuItem::Simple(SimpleMenuItem {
+                        id: CONTEXT_ITEM_IMPORT_CONFIG,
+                        label: "Import config".to_string(),
                     }),
                     MenuItem::Simple(SimpleMenuItem {
                         id: CONTEXT_ITEM_OPEN_CONFIG_FOLDER,
@@ -175,7 +185,15 @@ impl Middleware for ContextMenuMiddleware {
                         ));
                         Event::caused_by(event.source_id, EventType::NOOP)
                     }
-                    9_u32..=u32::MAX => {
+                    CONTEXT_ITEM_EXPORT_CONFIG => {
+                        dispatch(Event::caused_by(event.source_id, EventType::ExportConfig));
+                        Event::caused_by(event.source_id, EventType::NOOP)
+                    }
+                    CONTEXT_ITEM_IMPORT_CONFIG => {
+                        dispatch(Event::caused_by(event.source_id, EventType::ImportConfig));
+                        Event::caused_by(event.source_id, EventType::NOOP)
+                    }
+                    11_u32..=u32::MAX => {
                         // Should be unreachable, given there are no other options
                         unreachable!()
                     }

--- a/espanso-inject/src/evdev/mod.rs
+++ b/espanso-inject/src/evdev/mod.rs
@@ -31,7 +31,7 @@ use std::{
 
 use context::Context;
 use keymap::Keymap;
-use log::{error, warn};
+use log::warn;
 use uinput::UInputDevice;
 
 use crate::{

--- a/espanso-inject/src/mac/mod.rs
+++ b/espanso-inject/src/mac/mod.rs
@@ -21,7 +21,6 @@ mod raw_keys;
 
 use std::{ffi::CString, os::raw::c_char};
 
-use log::error;
 use raw_keys::convert_key_to_vkey;
 
 use anyhow::Result;

--- a/espanso-inject/src/win32/mod.rs
+++ b/espanso-inject/src/win32/mod.rs
@@ -19,7 +19,6 @@
 
 mod raw_keys;
 
-use log::error;
 use raw_keys::convert_key_to_vkey;
 
 use anyhow::Result;

--- a/espanso-inject/src/x11/default/mod.rs
+++ b/espanso-inject/src/x11/default/mod.rs
@@ -30,7 +30,7 @@ use crate::x11::ffi::{
     XSendEvent, XSync, XTestFakeKeyEvent,
 };
 use libc::c_void;
-use log::{debug, error};
+use log::debug;
 
 use crate::{linux::raw_keys::convert_to_sym_array, x11::ffi::Xutf8LookupString};
 use anyhow::{bail, Result};

--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -130,6 +130,8 @@ fn build_native() {
 
     cc::Build::new()
         .cpp(true)
+        .file("src/sys/export_dialog/export_dialog.cpp")
+        .file("src/sys/import_dialog/import_dialog.cpp")
         .file("src/sys/form/form.cpp")
         .file("src/sys/search/search.cpp")
         .file("src/sys/common/common.cpp")
@@ -190,11 +192,12 @@ fn build_native() {
 
     let is_arm64_ci = std::env::var("CI").unwrap_or_default() == "true" && target_arch == "arm64";
 
+    let build_cocoa_dir = out_wx_dir.join("build-cocoa");
     if !out_wx_dir.is_dir()
-        || out_wx_dir
-            .join("build-cocoa")
+        || !build_cocoa_dir.exists()
+        || build_cocoa_dir
             .read_dir()
-            .expect("unable to read the `out_wx_dir` variable")
+            .expect("unable to read the `build-cocoa` directory")
             .next()
             .is_none()
     {
@@ -281,6 +284,8 @@ fn build_native() {
     let mut build = cc::Build::new();
     build
         .cpp(true)
+        .file("src/sys/export_dialog/export_dialog.cpp")
+        .file("src/sys/import_dialog/import_dialog.cpp")
         .file("src/sys/form/form.cpp")
         .file("src/sys/common/common.cpp")
         .file("src/sys/search/search.cpp")
@@ -476,6 +481,8 @@ fn build_native() {
     let mut build = cc::Build::new();
     build
         .cpp(true)
+        .file("src/sys/export_dialog/export_dialog.cpp")
+        .file("src/sys/import_dialog/import_dialog.cpp")
         .file("src/sys/form/form.cpp")
         .file("src/sys/search/search.cpp")
         .file("src/sys/common/common.cpp")

--- a/espanso-modulo/src/export_dialog.rs
+++ b/espanso-modulo/src/export_dialog.rs
@@ -17,18 +17,13 @@
  * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-pub mod export_dialog;
-pub mod form;
-pub mod import_dialog;
-pub mod search;
-pub mod textview;
-pub mod troubleshooting;
-pub mod welcome;
-pub mod wizard;
-
-#[allow(non_upper_case_globals)]
-#[allow(dead_code)]
-#[allow(non_snake_case)]
-pub mod interop;
-
-mod util;
+pub fn show(
+    icon_path: Option<&str>,
+    generate_export_code: extern "C" fn(
+        export_config: std::os::raw::c_int,
+        export_matches: std::os::raw::c_int,
+        export_packages: std::os::raw::c_int,
+    ) -> *const std::os::raw::c_char,
+) {
+    crate::sys::export_dialog::show(icon_path, generate_export_code);
+}

--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -78,6 +78,7 @@ pub enum FieldTypeConfig {
     Text(TextFieldConfig),
     Choice(ChoiceFieldConfig),
     List(ListFieldConfig),
+    Checkbox(CheckboxFieldConfig),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -97,6 +98,11 @@ pub struct ListFieldConfig {
     pub values: Vec<String>,
     pub default: String,
     pub separator: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct CheckboxFieldConfig {
+    pub default: bool,
 }
 
 impl<'de> serde::Deserialize<'de> for FieldConfig {
@@ -148,6 +154,13 @@ impl<'a> From<&'a AutoFieldConfig> for FieldConfig {
                 config.separator.clone_from(&other.separator);
 
                 FieldTypeConfig::List(config)
+            }
+            "checkbox" => {
+                let config = CheckboxFieldConfig {
+                    default: other.default.as_deref().unwrap_or("false") == "true",
+                };
+
+                FieldTypeConfig::Checkbox(config)
             }
             _ => {
                 panic!("invalid field type: {}", other.field_type);

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -59,6 +59,7 @@ fn create_field(token: &Token, field_map: &HashMap<String, FieldConfig>) -> Fiel
                     default_value: config.default.clone(),
                     separator: config.separator.clone(),
                 }),
+                FieldTypeConfig::Checkbox(config) => FieldType::Checkbox(config.default),
             };
 
             Field {

--- a/espanso-modulo/src/import_dialog.rs
+++ b/espanso-modulo/src/import_dialog.rs
@@ -1,0 +1,39 @@
+/*
+ * This file is part of modulo.
+ *
+ * Copyright (C) 2020-2021 Federico Terzi
+ *
+ * modulo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * modulo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+pub fn show(
+    icon_path: Option<&str>,
+    validate_import_data: extern "C" fn(
+        data: *const std::os::raw::c_char,
+        config_status: *mut std::os::raw::c_int,
+        matches_status: *mut std::os::raw::c_int,
+        packages_status: *mut std::os::raw::c_int,
+    ) -> std::os::raw::c_int,
+    perform_import: extern "C" fn(
+        data: *const std::os::raw::c_char,
+        import_config: std::os::raw::c_int,
+        import_matches: std::os::raw::c_int,
+        import_packages: std::os::raw::c_int,
+        clear_config: std::os::raw::c_int,
+        clear_matches: std::os::raw::c_int,
+        clear_packages: std::os::raw::c_int,
+    ) -> std::os::raw::c_int,
+) {
+    crate::sys::import_dialog::show(icon_path, validate_import_data, perform_import);
+}

--- a/espanso-modulo/src/lib.rs
+++ b/espanso-modulo/src/lib.rs
@@ -17,7 +17,9 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+pub mod export_dialog;
 pub mod form;
+pub mod import_dialog;
 pub mod search;
 mod sys;
 pub mod textview;

--- a/espanso-modulo/src/sys/export_dialog/export_dialog.cpp
+++ b/espanso-modulo/src/sys/export_dialog/export_dialog.cpp
@@ -1,0 +1,235 @@
+/*
+ * This file is part of modulo.
+ *
+ * Copyright (C) 2020-2021 Federico Terzi
+ *
+ * modulo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * modulo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../common/common.h"
+#include "../interop/interop.h"
+#include <wx/clipbrd.h>
+
+#ifdef __WXMSW__
+#include <windows.h>
+#endif
+
+// Window style - stay on top so dialog doesn't get lost behind other windows
+const long EXPORT_DIALOG_STYLE = wxDEFAULT_FRAME_STYLE | wxSTAY_ON_TOP;
+
+// Forward declarations
+class ExportFrame;
+
+// Metadata pointer for callback
+const ExportDialogMetadata *g_exportMetadata = nullptr;
+
+// Application class
+class ExportDialogApp : public wxApp {
+public:
+    virtual bool OnInit() wxOVERRIDE;
+};
+
+// Frame class (using wxFrame like other modulo dialogs)
+class ExportFrame : public wxFrame {
+public:
+    ExportFrame(const wxString &title, const wxPoint &pos, const wxSize &size);
+
+private:
+    // Event handlers
+    void OnCheckboxChanged(wxCommandEvent &event);
+    void OnCopyButton(wxCommandEvent &event);
+    void OnCloseButton(wxCommandEvent &event);
+    void OnClose(wxCloseEvent &event);
+
+    // Helper methods
+    void UpdatePreview();
+    wxString GenerateExportCode();
+
+    // UI controls
+    wxPanel *m_panel;
+    wxCheckBox *m_configCheckbox;
+    wxCheckBox *m_matchesCheckbox;
+    wxCheckBox *m_packagesCheckbox;
+    wxTextCtrl *m_previewText;
+    wxButton *m_copyButton;
+    wxButton *m_closeButton;
+};
+
+// Application implementation
+bool ExportDialogApp::OnInit() {
+    if (!wxApp::OnInit()) {
+        return false;
+    }
+
+    ExportFrame *frame = new ExportFrame(
+        "Export Espanso Configuration",
+        wxDefaultPosition,
+        wxSize(700, 550)
+    );
+
+    if (g_exportMetadata && g_exportMetadata->window_icon_path) {
+        setFrameIcon(wxString::FromUTF8(g_exportMetadata->window_icon_path), frame);
+    }
+
+    frame->Show(true);
+    Activate(frame);
+
+    return true;
+}
+
+// Frame implementation
+ExportFrame::ExportFrame(const wxString &title, const wxPoint &pos, const wxSize &size)
+    : wxFrame(NULL, wxID_ANY, title, pos, size, EXPORT_DIALOG_STYLE)
+{
+    m_panel = new wxPanel(this, wxID_ANY);
+
+    // Create main vertical sizer
+    wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
+
+    // Title text
+    wxStaticText *titleText = new wxStaticText(m_panel, wxID_ANY,
+        "Select what to export:");
+    mainSizer->Add(titleText, 0, wxALL, 10);
+
+    // Checkboxes section
+    m_configCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Config Files");
+    m_configCheckbox->SetValue(true);
+    m_configCheckbox->Bind(wxEVT_CHECKBOX, &ExportFrame::OnCheckboxChanged, this);
+    mainSizer->Add(m_configCheckbox, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    m_matchesCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Matches");
+    m_matchesCheckbox->SetValue(true);
+    m_matchesCheckbox->Bind(wxEVT_CHECKBOX, &ExportFrame::OnCheckboxChanged, this);
+    mainSizer->Add(m_matchesCheckbox, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    m_packagesCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Packages");
+    m_packagesCheckbox->SetValue(true);
+    m_packagesCheckbox->Bind(wxEVT_CHECKBOX, &ExportFrame::OnCheckboxChanged, this);
+    mainSizer->Add(m_packagesCheckbox, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Preview label
+    wxStaticText *previewLabel = new wxStaticText(m_panel, wxID_ANY,
+        "Export Code (copy and save this):");
+    mainSizer->Add(previewLabel, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Preview text control with monospace font
+    m_previewText = new wxTextCtrl(m_panel, wxID_ANY, wxEmptyString,
+        wxDefaultPosition, wxSize(600, 300),
+        wxTE_MULTILINE | wxTE_READONLY);
+
+    wxFont monoFont(12, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+    m_previewText->SetFont(monoFont);
+
+    mainSizer->Add(m_previewText, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Button sizer (horizontal)
+    wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+
+    m_copyButton = new wxButton(m_panel, wxID_ANY, "Copy to Clipboard");
+    m_copyButton->Bind(wxEVT_BUTTON, &ExportFrame::OnCopyButton, this);
+    buttonSizer->Add(m_copyButton, 0, wxRIGHT, 5);
+
+    m_closeButton = new wxButton(m_panel, wxID_CLOSE, "Close");
+    m_closeButton->Bind(wxEVT_BUTTON, &ExportFrame::OnCloseButton, this);
+    buttonSizer->Add(m_closeButton, 0);
+
+    mainSizer->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 10);
+
+    // Set sizer
+    m_panel->SetSizer(mainSizer);
+
+    // Bind close event
+    Bind(wxEVT_CLOSE_WINDOW, &ExportFrame::OnClose, this);
+
+    // Center on screen
+    Centre();
+
+    // Generate initial preview
+    UpdatePreview();
+}
+
+void ExportFrame::OnCheckboxChanged(wxCommandEvent &event) {
+    UpdatePreview();
+}
+
+void ExportFrame::OnCopyButton(wxCommandEvent &event) {
+    if (wxTheClipboard->Open()) {
+        wxTheClipboard->SetData(new wxTextDataObject(m_previewText->GetValue()));
+        wxTheClipboard->Close();
+
+        // Visual feedback
+        wxString originalLabel = m_copyButton->GetLabel();
+        m_copyButton->SetLabel("Copied!");
+        m_copyButton->Refresh();
+        m_copyButton->Update();
+
+        wxMilliSleep(800);
+
+        m_copyButton->SetLabel(originalLabel);
+        m_copyButton->Refresh();
+    }
+}
+
+void ExportFrame::OnCloseButton(wxCommandEvent &event) {
+    Close(true);
+}
+
+void ExportFrame::OnClose(wxCloseEvent &event) {
+    Destroy();
+}
+
+void ExportFrame::UpdatePreview() {
+    wxString exportCode = GenerateExportCode();
+    m_previewText->SetValue(exportCode);
+}
+
+wxString ExportFrame::GenerateExportCode() {
+    int exportConfig = m_configCheckbox->GetValue() ? 1 : 0;
+    int exportMatches = m_matchesCheckbox->GetValue() ? 1 : 0;
+    int exportPackages = m_packagesCheckbox->GetValue() ? 1 : 0;
+
+    // If nothing is selected, show empty field
+    if (!exportConfig && !exportMatches && !exportPackages) {
+        return "";
+    }
+
+    if (!g_exportMetadata || !g_exportMetadata->generate_export_code) {
+        return "Error: Export function not available";
+    }
+
+    const char *code = g_exportMetadata->generate_export_code(
+        exportConfig, exportMatches, exportPackages);
+
+    if (code) {
+        return wxString::FromUTF8(code);
+    }
+
+    return "Error generating export code";
+}
+
+// C interface
+extern "C" void interop_show_export_dialog(const ExportDialogMetadata *metadata) {
+// Setup high DPI support on Windows
+#ifdef __WXMSW__
+    SetProcessDPIAware();
+#endif
+
+    g_exportMetadata = metadata;
+
+    wxApp::SetInstance(new ExportDialogApp());
+
+    int argc = 0;
+    char **argv = NULL;
+    wxEntry(argc, argv);
+}

--- a/espanso-modulo/src/sys/export_dialog/mod.rs
+++ b/espanso-modulo/src/sys/export_dialog/mod.rs
@@ -1,0 +1,44 @@
+/*
+ * This file is part of modulo.
+ *
+ * Copyright (C) 2020-2021 Federico Terzi
+ *
+ * modulo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * modulo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::ffi::CString;
+
+pub fn show(
+    icon_path: Option<&str>,
+    generate_export_code: extern "C" fn(
+        export_config: std::os::raw::c_int,
+        export_matches: std::os::raw::c_int,
+        export_packages: std::os::raw::c_int,
+    ) -> *const std::os::raw::c_char,
+) {
+    let icon_path_c = icon_path
+        .map(|path| CString::new(path).expect("unable to create CString for icon path"));
+
+    let export_dialog_metadata = super::interop::ExportDialogMetadata {
+        window_icon_path: icon_path_c
+            .as_ref()
+            .map(|c| c.as_ptr())
+            .unwrap_or(std::ptr::null()),
+        generate_export_code,
+    };
+
+    unsafe {
+        super::interop::interop_show_export_dialog(&export_dialog_metadata);
+    }
+}

--- a/espanso-modulo/src/sys/form/form.cpp
+++ b/espanso-modulo/src/sys/form/form.cpp
@@ -83,9 +83,22 @@ class ListFieldWrapper {
     }
 };
 
+class CheckboxFieldWrapper : public FieldWrapper {
+private:
+  wxCheckBox *control;
+
+public:
+  explicit CheckboxFieldWrapper(wxCheckBox *control) : control(control) {}
+
+  virtual wxString getValue() { 
+    return control->GetValue() ? wxString("true") : wxString("false"); 
+  }
+};
+
 // App Code
 
 class FormApp : public wxApp {
+
   public:
     virtual bool OnInit();
 };
@@ -267,6 +280,21 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
 
         control = choice;
         fields.push_back(choice);
+        break;
+    }
+    case FieldType::CHECKBOX: {
+        bool defaultValue = *static_cast<const bool *>(meta.specific);
+        
+        auto checkBox = new wxCheckBox(parent, wxID_ANY, wxEmptyString);
+        checkBox->SetValue(defaultValue);
+        checkBox->Bind(wxEVT_SET_FOCUS, &FormFrame::HandleNormalFocus, this, wxID_ANY);
+        
+        // Create the field wrapper
+        std::unique_ptr<FieldWrapper> field(
+            (FieldWrapper *)new CheckboxFieldWrapper(checkBox));
+        idMap[meta.id] = std::move(field);
+        control = checkBox;
+        fields.push_back(checkBox);
         break;
     }
     case FieldType::ROW: {

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -55,6 +55,7 @@ pub mod types {
         Label(LabelMetadata),
         Text(TextMetadata),
         Choice(ChoiceMetadata),
+        Checkbox(bool),
     }
 
     #[derive(Debug)]
@@ -96,7 +97,7 @@ mod interop {
 
     use super::super::interop::{
         ChoiceMetadata, ChoiceType_DROPDOWN, ChoiceType_LIST, FieldMetadata, FieldType,
-        FieldType_CHOICE, FieldType_LABEL, FieldType_ROW, FieldType_TEXT, FormMetadata,
+        FieldType_CHECKBOX, FieldType_CHOICE, FieldType_LABEL, FieldType_ROW, FieldType_TEXT, FormMetadata,
         Interoperable, LabelMetadata, RowMetadata, TextMetadata,
     };
     use super::types;
@@ -183,6 +184,7 @@ mod interop {
                 types::FieldType::Label(_) => FieldType_LABEL,
                 types::FieldType::Text(_) => FieldType_TEXT,
                 types::FieldType::Choice(_) => FieldType_CHOICE,
+                types::FieldType::Checkbox(_) => FieldType_CHECKBOX,
                 types::FieldType::Unknown => panic!("unknown field type"),
             };
 
@@ -203,6 +205,9 @@ mod interop {
                 types::FieldType::Choice(metadata) => {
                     let owned_metadata: OwnedChoiceMetadata = metadata.into();
                     Box::new(owned_metadata)
+                }
+                types::FieldType::Checkbox(default_value) => {
+                    Box::new(default_value)
                 }
                 types::FieldType::Unknown => panic!("unknown field type"),
             };
@@ -337,6 +342,12 @@ mod interop {
 
         metadata: Vec<FieldMetadata>,
         interop: Box<RowMetadata>,
+    }
+
+    impl Interoperable for bool {
+        fn as_ptr(&self) -> *const c_void {
+            self as *const bool as *const c_void
+        }
     }
 
     impl Interoperable for OwnedRowMetadata {

--- a/espanso-modulo/src/sys/import_dialog/import_dialog.cpp
+++ b/espanso-modulo/src/sys/import_dialog/import_dialog.cpp
@@ -1,0 +1,484 @@
+/*
+ * This file is part of modulo.
+ *
+ * Copyright (C) 2020-2021 Federico Terzi
+ *
+ * modulo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * modulo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../common/common.h"
+#include "../interop/interop.h"
+#include <wx/clipbrd.h>
+#include <wx/statline.h>
+
+#ifdef __WXMSW__
+#include <windows.h>
+#endif
+
+// Window style - stay on top so dialog doesn't get lost behind other windows
+const long IMPORT_DIALOG_STYLE = wxDEFAULT_FRAME_STYLE | wxSTAY_ON_TOP;
+
+// Layout constants
+const int IMPORT_CHECKBOX_WIDTH = 120;
+const int STATUS_LABEL_WIDTH = 140;
+const int CLEAR_CHECKBOX_WIDTH = 200;
+
+// Forward declarations
+class ImportFrame;
+
+// Metadata pointer for callback
+const ImportDialogMetadata *g_importMetadata = nullptr;
+
+// Application class
+class ImportDialogApp : public wxApp {
+public:
+    virtual bool OnInit() wxOVERRIDE;
+};
+
+// Frame class
+class ImportFrame : public wxFrame {
+public:
+    ImportFrame(const wxString &title, const wxPoint &pos, const wxSize &size);
+
+private:
+    // Event handlers
+    void OnPasteButton(wxCommandEvent &event);
+    void OnCheckButton(wxCommandEvent &event);
+    void OnImportButton(wxCommandEvent &event);
+    void OnCloseButton(wxCommandEvent &event);
+    void OnClose(wxCloseEvent &event);
+    void OnTextLostFocus(wxFocusEvent &event);
+    void OnImportCheckboxChanged(wxCommandEvent &event);
+
+    // Helper methods
+    void ValidateAndUpdateUI();
+    void UpdateRowUI(wxCheckBox *importCheckbox, wxStaticText *statusLabel,
+                     wxCheckBox *clearCheckbox, int status, int prevStatus);
+    void UpdateImportButtonState();
+
+    // UI controls
+    wxPanel *m_panel;
+    wxTextCtrl *m_inputText;
+    wxButton *m_pasteButton;
+    wxButton *m_checkButton;
+
+    // Row controls: import checkbox, status label, clear checkbox
+    wxCheckBox *m_importConfigCheckbox;
+    wxStaticText *m_configStatusLabel;
+    wxCheckBox *m_clearConfigCheckbox;
+
+    wxCheckBox *m_importMatchesCheckbox;
+    wxStaticText *m_matchesStatusLabel;
+    wxCheckBox *m_clearMatchesCheckbox;
+
+    wxCheckBox *m_importPackagesCheckbox;
+    wxStaticText *m_packagesStatusLabel;
+    wxCheckBox *m_clearPackagesCheckbox;
+
+    wxButton *m_importButton;
+    wxButton *m_closeButton;
+
+    // Validation state
+    bool m_isValid;
+    int m_configStatusValue;
+    int m_matchesStatusValue;
+    int m_packagesStatusValue;
+
+    // Previous status values (to detect transitions)
+    int m_prevConfigStatus;
+    int m_prevMatchesStatus;
+    int m_prevPackagesStatus;
+};
+
+// Application implementation
+bool ImportDialogApp::OnInit() {
+    if (!wxApp::OnInit()) {
+        return false;
+    }
+
+    ImportFrame *frame = new ImportFrame(
+        "Import Espanso Configuration",
+        wxDefaultPosition,
+        wxSize(580, 480)
+    );
+
+    if (g_importMetadata && g_importMetadata->window_icon_path) {
+        setFrameIcon(wxString::FromUTF8(g_importMetadata->window_icon_path), frame);
+    }
+
+    frame->Show(true);
+    Activate(frame);
+
+    return true;
+}
+
+// Frame implementation
+ImportFrame::ImportFrame(const wxString &title, const wxPoint &pos, const wxSize &size)
+    : wxFrame(NULL, wxID_ANY, title, pos, size, IMPORT_DIALOG_STYLE),
+      m_isValid(false),
+      m_configStatusValue(SCOPE_STATUS_EMPTY),
+      m_matchesStatusValue(SCOPE_STATUS_EMPTY),
+      m_packagesStatusValue(SCOPE_STATUS_EMPTY),
+      m_prevConfigStatus(SCOPE_STATUS_EMPTY),
+      m_prevMatchesStatus(SCOPE_STATUS_EMPTY),
+      m_prevPackagesStatus(SCOPE_STATUS_EMPTY)
+{
+    m_panel = new wxPanel(this, wxID_ANY);
+
+    // Create main vertical sizer
+    wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
+
+    // Instructions text
+    wxStaticText *instructionsText = new wxStaticText(m_panel, wxID_ANY,
+        "Paste the exported configuration code below:");
+    mainSizer->Add(instructionsText, 0, wxALL, 10);
+
+    // Input text control (editable, multiline)
+    m_inputText = new wxTextCtrl(m_panel, wxID_ANY, wxEmptyString,
+        wxDefaultPosition, wxSize(550, 180),
+        wxTE_MULTILINE);
+
+    wxFont monoFont(12, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+    m_inputText->SetFont(monoFont);
+    m_inputText->SetHint("Paste export code here...");
+
+    mainSizer->Add(m_inputText, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Button row: Paste and Check buttons
+    wxBoxSizer *pasteRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_pasteButton = new wxButton(m_panel, wxID_ANY, "Paste from Clipboard");
+    m_pasteButton->Bind(wxEVT_BUTTON, &ImportFrame::OnPasteButton, this);
+    pasteRowSizer->Add(m_pasteButton, 0, wxRIGHT, 10);
+
+    m_checkButton = new wxButton(m_panel, wxID_ANY, "Check import code");
+    m_checkButton->Bind(wxEVT_BUTTON, &ImportFrame::OnCheckButton, this);
+    pasteRowSizer->Add(m_checkButton, 0);
+
+    mainSizer->Add(pasteRowSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Separator
+    mainSizer->Add(new wxStaticLine(m_panel), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Header row
+    wxBoxSizer *headerSizer = new wxBoxSizer(wxHORIZONTAL);
+    wxStaticText *importHeader = new wxStaticText(m_panel, wxID_ANY, "Import");
+    wxFont boldFont = importHeader->GetFont();
+    boldFont.SetWeight(wxFONTWEIGHT_BOLD);
+    importHeader->SetFont(boldFont);
+    importHeader->SetMinSize(wxSize(IMPORT_CHECKBOX_WIDTH, -1));
+    headerSizer->Add(importHeader, 0, wxALIGN_CENTER_VERTICAL);
+
+    wxStaticText *statusHeader = new wxStaticText(m_panel, wxID_ANY, "Status");
+    statusHeader->SetFont(boldFont);
+    statusHeader->SetMinSize(wxSize(STATUS_LABEL_WIDTH, -1));
+    headerSizer->Add(statusHeader, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    wxStaticText *clearHeader = new wxStaticText(m_panel, wxID_ANY, "Clear before import");
+    clearHeader->SetFont(boldFont);
+    headerSizer->Add(clearHeader, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    mainSizer->Add(headerSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Config row
+    wxBoxSizer *configRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_importConfigCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Config");
+    m_importConfigCheckbox->SetValue(true);
+    m_importConfigCheckbox->SetMinSize(wxSize(IMPORT_CHECKBOX_WIDTH, -1));
+    m_importConfigCheckbox->Bind(wxEVT_CHECKBOX, &ImportFrame::OnImportCheckboxChanged, this);
+    configRowSizer->Add(m_importConfigCheckbox, 0, wxALIGN_CENTER_VERTICAL);
+
+    m_configStatusLabel = new wxStaticText(m_panel, wxID_ANY, "");
+    m_configStatusLabel->SetMinSize(wxSize(STATUS_LABEL_WIDTH, -1));
+    configRowSizer->Add(m_configStatusLabel, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    m_clearConfigCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Clear existing Config");
+    m_clearConfigCheckbox->SetValue(true);
+    configRowSizer->Add(m_clearConfigCheckbox, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    mainSizer->Add(configRowSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Matches row
+    wxBoxSizer *matchesRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_importMatchesCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Matches");
+    m_importMatchesCheckbox->SetValue(true);
+    m_importMatchesCheckbox->SetMinSize(wxSize(IMPORT_CHECKBOX_WIDTH, -1));
+    m_importMatchesCheckbox->Bind(wxEVT_CHECKBOX, &ImportFrame::OnImportCheckboxChanged, this);
+    matchesRowSizer->Add(m_importMatchesCheckbox, 0, wxALIGN_CENTER_VERTICAL);
+
+    m_matchesStatusLabel = new wxStaticText(m_panel, wxID_ANY, "");
+    m_matchesStatusLabel->SetMinSize(wxSize(STATUS_LABEL_WIDTH, -1));
+    matchesRowSizer->Add(m_matchesStatusLabel, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    m_clearMatchesCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Clear existing Matches");
+    m_clearMatchesCheckbox->SetValue(true);
+    matchesRowSizer->Add(m_clearMatchesCheckbox, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    mainSizer->Add(matchesRowSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Packages row
+    wxBoxSizer *packagesRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_importPackagesCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Packages");
+    m_importPackagesCheckbox->SetValue(true);
+    m_importPackagesCheckbox->SetMinSize(wxSize(IMPORT_CHECKBOX_WIDTH, -1));
+    m_importPackagesCheckbox->Bind(wxEVT_CHECKBOX, &ImportFrame::OnImportCheckboxChanged, this);
+    packagesRowSizer->Add(m_importPackagesCheckbox, 0, wxALIGN_CENTER_VERTICAL);
+
+    m_packagesStatusLabel = new wxStaticText(m_panel, wxID_ANY, "");
+    m_packagesStatusLabel->SetMinSize(wxSize(STATUS_LABEL_WIDTH, -1));
+    packagesRowSizer->Add(m_packagesStatusLabel, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    m_clearPackagesCheckbox = new wxCheckBox(m_panel, wxID_ANY, "Clear existing Packages");
+    m_clearPackagesCheckbox->SetValue(true);
+    packagesRowSizer->Add(m_clearPackagesCheckbox, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 10);
+
+    mainSizer->Add(packagesRowSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Separator
+    mainSizer->Add(new wxStaticLine(m_panel), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    // Button sizer (horizontal)
+    wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+
+    m_importButton = new wxButton(m_panel, wxID_ANY, "Import");
+    m_importButton->Bind(wxEVT_BUTTON, &ImportFrame::OnImportButton, this);
+    m_importButton->Disable();  // Disabled until valid data
+    buttonSizer->Add(m_importButton, 0, wxRIGHT, 5);
+
+    m_closeButton = new wxButton(m_panel, wxID_CLOSE, "Close");
+    m_closeButton->Bind(wxEVT_BUTTON, &ImportFrame::OnCloseButton, this);
+    buttonSizer->Add(m_closeButton, 0);
+
+    mainSizer->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 10);
+
+    // Set sizer
+    m_panel->SetSizer(mainSizer);
+
+    // Bind events
+    Bind(wxEVT_CLOSE_WINDOW, &ImportFrame::OnClose, this);
+    m_inputText->Bind(wxEVT_KILL_FOCUS, &ImportFrame::OnTextLostFocus, this);
+
+    // Center on screen
+    Centre();
+}
+
+void ImportFrame::OnPasteButton(wxCommandEvent &event) {
+    if (wxTheClipboard->Open()) {
+        if (wxTheClipboard->IsSupported(wxDF_TEXT)) {
+            wxTextDataObject data;
+            wxTheClipboard->GetData(data);
+            m_inputText->SetValue(data.GetText());
+        }
+        wxTheClipboard->Close();
+    }
+    ValidateAndUpdateUI();
+}
+
+void ImportFrame::OnCheckButton(wxCommandEvent &event) {
+    // Move focus away from text control to trigger validation
+    m_checkButton->SetFocus();
+    ValidateAndUpdateUI();
+}
+
+void ImportFrame::OnTextLostFocus(wxFocusEvent &event) {
+    ValidateAndUpdateUI();
+    event.Skip();
+}
+
+void ImportFrame::OnImportCheckboxChanged(wxCommandEvent &event) {
+    wxCheckBox *checkbox = dynamic_cast<wxCheckBox*>(event.GetEventObject());
+
+    // When import checkbox is unchecked, uncheck the corresponding clear checkbox
+    if (checkbox && !checkbox->GetValue()) {
+        if (checkbox == m_importConfigCheckbox) {
+            m_clearConfigCheckbox->SetValue(false);
+        } else if (checkbox == m_importMatchesCheckbox) {
+            m_clearMatchesCheckbox->SetValue(false);
+        } else if (checkbox == m_importPackagesCheckbox) {
+            m_clearPackagesCheckbox->SetValue(false);
+        }
+    }
+
+    UpdateImportButtonState();
+}
+
+void ImportFrame::ValidateAndUpdateUI() {
+    wxString inputText = m_inputText->GetValue();
+
+    // Reset status
+    m_configStatusValue = SCOPE_STATUS_EMPTY;
+    m_matchesStatusValue = SCOPE_STATUS_EMPTY;
+    m_packagesStatusValue = SCOPE_STATUS_EMPTY;
+    m_isValid = false;
+
+    if (!inputText.IsEmpty()) {
+        // Call validation callback if available
+        if (g_importMetadata && g_importMetadata->validate_import_data) {
+            std::string utf8Input = inputText.ToUTF8().data();
+            int result = g_importMetadata->validate_import_data(
+                utf8Input.c_str(),
+                &m_configStatusValue,
+                &m_matchesStatusValue,
+                &m_packagesStatusValue
+            );
+            m_isValid = (result != 0);
+        }
+    }
+
+    // Update each row's UI (pass previous status to detect transitions)
+    UpdateRowUI(m_importConfigCheckbox, m_configStatusLabel, m_clearConfigCheckbox,
+                m_configStatusValue, m_prevConfigStatus);
+    UpdateRowUI(m_importMatchesCheckbox, m_matchesStatusLabel, m_clearMatchesCheckbox,
+                m_matchesStatusValue, m_prevMatchesStatus);
+    UpdateRowUI(m_importPackagesCheckbox, m_packagesStatusLabel, m_clearPackagesCheckbox,
+                m_packagesStatusValue, m_prevPackagesStatus);
+
+    // Update previous status values
+    m_prevConfigStatus = m_configStatusValue;
+    m_prevMatchesStatus = m_matchesStatusValue;
+    m_prevPackagesStatus = m_packagesStatusValue;
+
+    UpdateImportButtonState();
+}
+
+void ImportFrame::UpdateRowUI(wxCheckBox *importCheckbox, wxStaticText *statusLabel,
+                               wxCheckBox *clearCheckbox, int status, int prevStatus) {
+    wxString text;
+    wxColour colour;
+
+    // Detect if status just transitioned to MISSING or INVALID
+    bool justBecameUnavailable = (status == SCOPE_STATUS_MISSING || status == SCOPE_STATUS_INVALID) &&
+                                  (prevStatus != SCOPE_STATUS_MISSING && prevStatus != SCOPE_STATUS_INVALID);
+
+    switch (status) {
+        case SCOPE_STATUS_EMPTY:
+            text = "";
+            colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            // Enable both checkboxes but don't change their state
+            importCheckbox->Enable(true);
+            clearCheckbox->Enable(true);
+            break;
+        case SCOPE_STATUS_PRESENT:
+            text = "(found in export)";
+            colour = wxColour(0, 160, 0);  // Green
+            // Enable both checkboxes
+            importCheckbox->Enable(true);
+            clearCheckbox->Enable(true);
+            break;
+        case SCOPE_STATUS_MISSING:
+            text = "(not in export)";
+            colour = wxColour(128, 128, 128);  // Gray
+            // Disable import checkbox but enable clear checkbox
+            importCheckbox->Enable(false);
+            importCheckbox->SetValue(false);
+            clearCheckbox->Enable(true);
+            // Only uncheck clear checkbox on transition to this state
+            if (justBecameUnavailable) {
+                clearCheckbox->SetValue(false);
+            }
+            break;
+        case SCOPE_STATUS_INVALID:
+            text = "(invalid data)";
+            colour = wxColour(200, 0, 0);  // Red
+            // Disable both checkboxes but preserve their state
+            importCheckbox->Enable(false);
+            clearCheckbox->Enable(false);
+            break;
+    }
+
+    statusLabel->SetLabel(text);
+    statusLabel->SetForegroundColour(colour);
+    statusLabel->Refresh();
+}
+
+void ImportFrame::UpdateImportButtonState() {
+    // Import button is enabled only if:
+    // 1. Data is valid (at least one scope present)
+    // 2. At least one "import" checkbox is checked for a present scope
+
+    bool canImport = false;
+
+    if (m_isValid) {
+        if (m_importConfigCheckbox->GetValue() && m_configStatusValue == SCOPE_STATUS_PRESENT) {
+            canImport = true;
+        }
+        if (m_importMatchesCheckbox->GetValue() && m_matchesStatusValue == SCOPE_STATUS_PRESENT) {
+            canImport = true;
+        }
+        if (m_importPackagesCheckbox->GetValue() && m_packagesStatusValue == SCOPE_STATUS_PRESENT) {
+            canImport = true;
+        }
+    }
+
+    m_importButton->Enable(canImport);
+}
+
+void ImportFrame::OnImportButton(wxCommandEvent &event) {
+    if (!m_isValid) {
+        return;
+    }
+
+    // Gather import and clear selections
+    int importConfig = (m_importConfigCheckbox->GetValue() && m_configStatusValue == SCOPE_STATUS_PRESENT) ? 1 : 0;
+    int importMatches = (m_importMatchesCheckbox->GetValue() && m_matchesStatusValue == SCOPE_STATUS_PRESENT) ? 1 : 0;
+    int importPackages = (m_importPackagesCheckbox->GetValue() && m_packagesStatusValue == SCOPE_STATUS_PRESENT) ? 1 : 0;
+
+    int clearConfig = m_clearConfigCheckbox->GetValue() ? 1 : 0;
+    int clearMatches = m_clearMatchesCheckbox->GetValue() ? 1 : 0;
+    int clearPackages = m_clearPackagesCheckbox->GetValue() ? 1 : 0;
+
+    // Perform import via callback
+    if (g_importMetadata && g_importMetadata->perform_import) {
+        wxString inputText = m_inputText->GetValue();
+        std::string utf8Input = inputText.ToUTF8().data();
+
+        int result = g_importMetadata->perform_import(
+            utf8Input.c_str(),
+            importConfig, importMatches, importPackages,
+            clearConfig, clearMatches, clearPackages
+        );
+
+        if (result != 0) {
+            wxMessageBox("Configuration imported successfully!\n\nEspanso will automatically detect the changes.",
+                        "Import Complete", wxOK | wxICON_INFORMATION);
+            Close(true);
+        } else {
+            wxMessageBox("An error occurred during import.\n\nPlease check the espanso logs for details.",
+                        "Import Error", wxOK | wxICON_ERROR);
+        }
+    }
+}
+
+void ImportFrame::OnCloseButton(wxCommandEvent &event) {
+    Close(true);
+}
+
+void ImportFrame::OnClose(wxCloseEvent &event) {
+    Destroy();
+}
+
+// C interface
+extern "C" void interop_show_import_dialog(const ImportDialogMetadata *metadata) {
+// Setup high DPI support on Windows
+#ifdef __WXMSW__
+    SetProcessDPIAware();
+#endif
+
+    g_importMetadata = metadata;
+
+    wxApp::SetInstance(new ImportDialogApp());
+
+    int argc = 0;
+    char **argv = NULL;
+    wxEntry(argc, argv);
+}

--- a/espanso-modulo/src/sys/import_dialog/mod.rs
+++ b/espanso-modulo/src/sys/import_dialog/mod.rs
@@ -1,0 +1,55 @@
+/*
+ * This file is part of modulo.
+ *
+ * Copyright (C) 2020-2021 Federico Terzi
+ *
+ * modulo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * modulo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::ffi::CString;
+
+pub fn show(
+    icon_path: Option<&str>,
+    validate_import_data: extern "C" fn(
+        data: *const std::os::raw::c_char,
+        config_status: *mut std::os::raw::c_int,
+        matches_status: *mut std::os::raw::c_int,
+        packages_status: *mut std::os::raw::c_int,
+    ) -> std::os::raw::c_int,
+    perform_import: extern "C" fn(
+        data: *const std::os::raw::c_char,
+        import_config: std::os::raw::c_int,
+        import_matches: std::os::raw::c_int,
+        import_packages: std::os::raw::c_int,
+        clear_config: std::os::raw::c_int,
+        clear_matches: std::os::raw::c_int,
+        clear_packages: std::os::raw::c_int,
+    ) -> std::os::raw::c_int,
+) {
+    let icon_path_c = icon_path
+        .map(|path| CString::new(path).expect("unable to create CString for icon path"));
+
+    let import_dialog_metadata = super::interop::ImportDialogMetadata {
+        window_icon_path: icon_path_c
+            .as_ref()
+            .map(|c| c.as_ptr())
+            .unwrap_or(std::ptr::null()),
+        validate_import_data,
+        perform_import,
+    };
+
+    unsafe {
+        super::interop::interop_show_import_dialog(&import_dialog_metadata);
+    }
+}

--- a/espanso-modulo/src/sys/interop/interop.h
+++ b/espanso-modulo/src/sys/interop/interop.h
@@ -179,3 +179,27 @@ typedef struct TextViewMetadata {
     const char *title;
     const char *content;
 } TextViewMetadata;
+
+// Export Dialog
+
+typedef struct ExportDialogMetadata {
+    const char *window_icon_path;
+    const char *(*generate_export_code)(int export_config, int export_matches, int export_packages);
+} ExportDialogMetadata;
+
+// Import Dialog
+
+// Scope status constants
+const int SCOPE_STATUS_EMPTY = 0;      // No data pasted yet
+const int SCOPE_STATUS_PRESENT = 1;    // Scope found in archive
+const int SCOPE_STATUS_MISSING = 2;    // Scope not found (archive is valid but scope absent)
+const int SCOPE_STATUS_INVALID = 3;    // Archive is invalid
+
+typedef struct ImportDialogMetadata {
+    const char *window_icon_path;
+    // Returns 1 if valid, 0 if invalid. Sets scope status values.
+    int (*validate_import_data)(const char *data, int *config_status, int *matches_status, int *packages_status);
+    // Returns 1 on success, 0 on failure
+    int (*perform_import)(const char *data, int import_config, int import_matches, int import_packages,
+                          int clear_config, int clear_matches, int clear_packages);
+} ImportDialogMetadata;

--- a/espanso-modulo/src/sys/interop/mod.rs
+++ b/espanso-modulo/src/sys/interop/mod.rs
@@ -195,6 +195,40 @@ pub struct TextViewMetadata {
     pub content: *const c_char,
 }
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExportDialogMetadata {
+    pub window_icon_path: *const c_char,
+    pub generate_export_code: extern "C" fn(export_config: c_int, export_matches: c_int, export_packages: c_int) -> *const c_char,
+}
+
+// Scope status constants for import validation
+pub const SCOPE_STATUS_EMPTY: c_int = 0;
+pub const SCOPE_STATUS_PRESENT: c_int = 1;
+pub const SCOPE_STATUS_MISSING: c_int = 2;
+pub const SCOPE_STATUS_INVALID: c_int = 3;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ImportDialogMetadata {
+    pub window_icon_path: *const c_char,
+    pub validate_import_data: extern "C" fn(
+        data: *const c_char,
+        config_status: *mut c_int,
+        matches_status: *mut c_int,
+        packages_status: *mut c_int,
+    ) -> c_int,
+    pub perform_import: extern "C" fn(
+        data: *const c_char,
+        import_config: c_int,
+        import_matches: c_int,
+        import_packages: c_int,
+        clear_config: c_int,
+        clear_matches: c_int,
+        clear_packages: c_int,
+    ) -> c_int,
+}
+
 // Native bindings
 
 #[allow(improper_ctypes)]
@@ -233,4 +267,10 @@ extern "C" {
 
     // TEXTVIEW
     pub(crate) fn interop_show_text_view(metadata: *const TextViewMetadata);
+
+    // EXPORT DIALOG
+    pub(crate) fn interop_show_export_dialog(metadata: *const ExportDialogMetadata);
+
+    // IMPORT DIALOG
+    pub(crate) fn interop_show_import_dialog(metadata: *const ImportDialogMetadata);
 }

--- a/espanso-modulo/src/sys/textview/textview.cpp
+++ b/espanso-modulo/src/sys/textview/textview.cpp
@@ -48,7 +48,7 @@ class DerivedTextViewFrame : public TextViewFrame {
 };
 
 DerivedTextViewFrame::DerivedTextViewFrame(wxWindow *parent)
-    : TextViewFrame(parent) {
+    : TextViewFrame(parent, wxID_ANY, wxT("TextView"), wxDefaultPosition, wxSize(895, 545), wxDEFAULT_FRAME_STYLE | wxSTAY_ON_TOP) {
     this->text_content->SetValue(
         wxString::FromUTF8(text_view_metadata->content));
     this->SetTitle(wxString::FromUTF8(text_view_metadata->title));

--- a/espanso-modulo/src/sys/troubleshooting/troubleshooting.cpp
+++ b/espanso-modulo/src/sys/troubleshooting/troubleshooting.cpp
@@ -140,7 +140,7 @@ class DerivedTroubleshootingFrame : public TroubleshootingFrame {
 };
 
 DerivedTroubleshootingFrame::DerivedTroubleshootingFrame(wxWindow *parent)
-    : TroubleshootingFrame(parent) {
+    : TroubleshootingFrame(parent, wxID_ANY, wxT("Troubleshooting"), wxDefaultPosition, wxSize(841, 544), wxDEFAULT_FRAME_STYLE | wxSTAY_ON_TOP) {
     if (troubleshooting_metadata->error_sets_count == 0) {
         dont_show_checkbox->Hide();
         ignore_button->Hide();

--- a/espanso-modulo/src/sys/welcome/welcome.cpp
+++ b/espanso-modulo/src/sys/welcome/welcome.cpp
@@ -46,7 +46,7 @@ class DerivedWelcomeFrame : public WelcomeFrame {
 };
 
 DerivedWelcomeFrame::DerivedWelcomeFrame(wxWindow *parent)
-    : WelcomeFrame(parent) {
+    : WelcomeFrame(parent, wxID_ANY, wxT("Espanso is running!"), wxDefaultPosition, wxSize(521, 597), wxCAPTION | wxCLOSE_BOX | wxSYSTEM_MENU | wxSTAY_ON_TOP) {
     // Welcome images
 
     if (welcome_metadata->tray_image_path) {

--- a/espanso-modulo/src/sys/wizard/wizard.cpp
+++ b/espanso-modulo/src/sys/wizard/wizard.cpp
@@ -112,7 +112,7 @@ class DerivedFrame : public WizardFrame {
     DerivedFrame(wxWindow *parent);
 };
 
-DerivedFrame::DerivedFrame(wxWindow *parent) : WizardFrame(parent) {
+DerivedFrame::DerivedFrame(wxWindow *parent) : WizardFrame(parent, wxID_ANY, wxT("Espanso"), wxDefaultPosition, wxSize(600, 577), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER | wxSYSTEM_MENU | wxSTAY_ON_TOP) {
     // Welcome images
 
     if (wizard_metadata->welcome_image_path) {

--- a/espanso-render/src/extension/choice.rs
+++ b/espanso-render/src/extension/choice.rs
@@ -18,7 +18,6 @@
  */
 
 use anyhow::Result;
-use log::error;
 use thiserror::Error;
 
 use crate::{Extension, ExtensionOutput, ExtensionResult, Params, Value};

--- a/espanso-render/src/extension/form.rs
+++ b/espanso-render/src/extension/form.rs
@@ -17,7 +17,6 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use log::error;
 use std::{collections::HashMap, sync::LazyLock};
 use thiserror::Error;
 

--- a/espanso/Cargo.toml
+++ b/espanso/Cargo.toml
@@ -71,6 +71,10 @@ notify = "4.0.17"
 opener = "0.5.0"
 sysinfo = "0.28.4"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
+base64 = "0.21.7"
+flate2 = "1.0.30"
+tar = "0.4.40"
+walkdir.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 widestring.workspace = true

--- a/espanso/src/cli/mod.rs
+++ b/espanso/src/cli/mod.rs
@@ -31,6 +31,7 @@ pub mod launcher;
 pub mod log;
 pub mod match_cli;
 pub mod modulo;
+pub mod offline;
 pub mod package;
 pub mod path;
 pub mod service;

--- a/espanso/src/cli/modulo/export_dialog.rs
+++ b/espanso/src/cli/modulo/export_dialog.rs
@@ -1,0 +1,91 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::icon::IconPaths;
+use clap::ArgMatches;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+// Global state to pass paths to the C callback
+static EXPORT_CONTEXT: Mutex<Option<ExportContext>> = Mutex::new(None);
+
+struct ExportContext {
+    runtime_path: PathBuf,
+    config_path: PathBuf,
+}
+
+extern "C" fn generate_export_code_callback(
+    export_config: std::os::raw::c_int,
+    export_matches: std::os::raw::c_int,
+    export_packages: std::os::raw::c_int,
+) -> *const c_char {
+    let context = EXPORT_CONTEXT.lock().unwrap();
+    if let Some(ctx) = context.as_ref() {
+        match crate::cli::offline::export_config_to_string(
+            &ctx.runtime_path,
+            &ctx.config_path,
+            export_config != 0,
+            export_matches != 0,
+            export_packages != 0,
+        ) {
+            Ok(export_code) => {
+                let c_string = CString::new(export_code).unwrap_or_else(|_| CString::new("Error: Invalid export code").unwrap());
+                c_string.into_raw()
+            }
+            Err(err) => {
+                let error_msg = format!("Error: {}", err);
+                let c_string = CString::new(error_msg).unwrap_or_else(|_| CString::new("Error generating export code").unwrap());
+                c_string.into_raw()
+            }
+        }
+    } else {
+        let c_string = CString::new("Error: Export context not initialized").unwrap();
+        c_string.into_raw()
+    }
+}
+
+pub fn export_dialog_main(args: &ArgMatches, icon_paths: &IconPaths) -> i32 {
+    let runtime_path = args.value_of("runtime_path").expect("missing runtime_path");
+    let config_path = args.value_of("config_path").expect("missing config_path");
+
+    // Set up the export context for the callback
+    {
+        let mut context = EXPORT_CONTEXT.lock().unwrap();
+        *context = Some(ExportContext {
+            runtime_path: PathBuf::from(runtime_path),
+            config_path: PathBuf::from(config_path),
+        });
+    }
+
+    // Show the custom export dialog with checkboxes and live preview
+    espanso_modulo::export_dialog::show(
+        icon_paths.wizard_icon.as_ref().map(|p| p.to_string_lossy().to_string()).as_deref(),
+        generate_export_code_callback
+    );
+
+    // Clean up the context
+    {
+        let mut context = EXPORT_CONTEXT.lock().unwrap();
+        *context = None;
+    }
+
+    0
+}

--- a/espanso/src/cli/modulo/import_dialog.rs
+++ b/espanso/src/cli/modulo/import_dialog.rs
@@ -1,0 +1,378 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::icon::IconPaths;
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use clap::ArgMatches;
+use flate2::read::GzDecoder;
+use log::error;
+use std::ffi::CStr;
+use std::io::Read;
+use std::os::raw::{c_char, c_int};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use tar::Archive;
+
+// Scope status constants (must match C++ side)
+const SCOPE_STATUS_EMPTY: c_int = 0;
+const SCOPE_STATUS_PRESENT: c_int = 1;
+const SCOPE_STATUS_MISSING: c_int = 2;
+const SCOPE_STATUS_INVALID: c_int = 3;
+
+// Global state to pass paths to the C callbacks
+static IMPORT_CONTEXT: Mutex<Option<ImportContext>> = Mutex::new(None);
+
+struct ImportContext {
+    config_path: PathBuf,
+}
+
+extern "C" fn validate_import_data_callback(
+    data: *const c_char,
+    config_status: *mut c_int,
+    matches_status: *mut c_int,
+    packages_status: *mut c_int,
+) -> c_int {
+    // Safety: Set all to invalid initially
+    unsafe {
+        *config_status = SCOPE_STATUS_INVALID;
+        *matches_status = SCOPE_STATUS_INVALID;
+        *packages_status = SCOPE_STATUS_INVALID;
+    }
+
+    if data.is_null() {
+        return 0;
+    }
+
+    let data_str = unsafe {
+        match CStr::from_ptr(data).to_str() {
+            Ok(s) => s,
+            Err(_) => return 0,
+        }
+    };
+
+    if data_str.is_empty() {
+        unsafe {
+            *config_status = SCOPE_STATUS_EMPTY;
+            *matches_status = SCOPE_STATUS_EMPTY;
+            *packages_status = SCOPE_STATUS_EMPTY;
+        }
+        return 0;
+    }
+
+    // Try to validate the archive and detect scopes
+    match validate_archive_and_detect_scopes(data_str) {
+        Ok((has_config, has_matches, has_packages)) => {
+            unsafe {
+                *config_status = if has_config { SCOPE_STATUS_PRESENT } else { SCOPE_STATUS_MISSING };
+                *matches_status = if has_matches { SCOPE_STATUS_PRESENT } else { SCOPE_STATUS_MISSING };
+                *packages_status = if has_packages { SCOPE_STATUS_PRESENT } else { SCOPE_STATUS_MISSING };
+            }
+            // Valid if at least one scope is present
+            if has_config || has_matches || has_packages {
+                1
+            } else {
+                0
+            }
+        }
+        Err(e) => {
+            error!("Import validation error: {}", e);
+            // Write error to a temp file for debugging
+            let _ = std::fs::write("/tmp/espanso_import_debug.txt", format!("Validation error: {}\nInput length: {}\nFirst 100 chars: {}", e, data_str.len(), &data_str[..data_str.len().min(100)]));
+            0
+        }
+    }
+}
+
+fn validate_archive_and_detect_scopes(data: &str) -> Result<(bool, bool, bool)> {
+    // Remove whitespace from base64 input
+    let filtered: String = data.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // Decode base64
+    let decoded = STANDARD.decode(&filtered).context("invalid base64 encoding")?;
+
+    // Decompress gzip
+    let mut gzip = GzDecoder::new(&decoded[..]);
+    let mut tar_data = Vec::new();
+    gzip.read_to_end(&mut tar_data).context("invalid gzip data")?;
+
+    // Read tar archive
+    let mut archive = Archive::new(&tar_data[..]);
+
+    let mut has_config = false;
+    let mut has_matches = false;
+    let mut has_packages = false;
+
+    for entry in archive.entries().context("invalid tar archive")? {
+        let entry = entry.context("failed to read archive entry")?;
+        let path = entry.path().context("failed to read entry path")?;
+        let path_str = path.to_string_lossy();
+
+        // Check which scopes are present based on directory prefixes
+        if path_str.starts_with("config/") || path_str == "config" {
+            has_config = true;
+        } else if path_str.starts_with("matches/") || path_str == "matches" {
+            has_matches = true;
+        } else if path_str.starts_with("packages/") || path_str == "packages" {
+            has_packages = true;
+        }
+    }
+
+    Ok((has_config, has_matches, has_packages))
+}
+
+extern "C" fn perform_import_callback(
+    data: *const c_char,
+    import_config: c_int,
+    import_matches: c_int,
+    import_packages: c_int,
+    clear_config: c_int,
+    clear_matches: c_int,
+    clear_packages: c_int,
+) -> c_int {
+    if data.is_null() {
+        return 0;
+    }
+
+    let data_str = unsafe {
+        match CStr::from_ptr(data).to_str() {
+            Ok(s) => s,
+            Err(_) => return 0,
+        }
+    };
+
+    let context = IMPORT_CONTEXT.lock().unwrap();
+    let ctx = match context.as_ref() {
+        Some(c) => c,
+        None => {
+            error!("Import context not initialized");
+            return 0;
+        }
+    };
+
+    match perform_import_internal(
+        data_str,
+        &ctx.config_path,
+        import_config != 0,
+        import_matches != 0,
+        import_packages != 0,
+        clear_config != 0,
+        clear_matches != 0,
+        clear_packages != 0,
+    ) {
+        Ok(()) => 1,
+        Err(e) => {
+            error!("Import failed: {}", e);
+            0
+        }
+    }
+}
+
+fn perform_import_internal(
+    data: &str,
+    config_path: &PathBuf,
+    import_config: bool,
+    import_matches: bool,
+    import_packages: bool,
+    clear_config: bool,
+    clear_matches: bool,
+    clear_packages: bool,
+) -> Result<()> {
+    use std::fs;
+    use tar::EntryType;
+
+    // Remove whitespace from base64 input
+    let filtered: String = data.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // Decode base64
+    let decoded = STANDARD.decode(&filtered).context("invalid base64 encoding")?;
+
+    // Decompress gzip
+    let mut gzip = GzDecoder::new(&decoded[..]);
+    let mut tar_data = Vec::new();
+    gzip.read_to_end(&mut tar_data).context("invalid gzip data")?;
+
+    // Prepare target directories
+    let config_dir = config_path.join("config");
+    let matches_dir = config_path.join("match");
+    let packages_dir = config_path.join("match").join("packages");
+
+    // Clear directories if requested (clearing can happen even without importing)
+    if clear_config {
+        if config_dir.exists() {
+            fs::remove_dir_all(&config_dir).context("failed to clear config directory")?;
+        }
+        if import_config {
+            fs::create_dir_all(&config_dir).context("failed to create config directory")?;
+        }
+    }
+
+    if clear_matches {
+        // Be careful not to delete packages if we're not clearing them
+        if matches_dir.exists() {
+            if clear_packages || !packages_dir.exists() {
+                fs::remove_dir_all(&matches_dir).context("failed to clear matches directory")?;
+            } else {
+                // Clear matches but preserve packages
+                clear_directory_except(&matches_dir, Some(&packages_dir))?;
+            }
+        }
+        if import_matches {
+            fs::create_dir_all(&matches_dir).context("failed to create matches directory")?;
+        }
+    }
+
+    if clear_packages {
+        if packages_dir.exists() {
+            fs::remove_dir_all(&packages_dir).context("failed to clear packages directory")?;
+        }
+        if import_packages {
+            fs::create_dir_all(&packages_dir).context("failed to create packages directory")?;
+        }
+    }
+
+    // Read tar archive and extract files
+    let mut archive = Archive::new(&tar_data[..]);
+
+    for entry in archive.entries().context("invalid tar archive")? {
+        let mut entry = entry.context("failed to read archive entry")?;
+        let entry_path = entry.path().context("failed to read entry path")?.to_path_buf();
+        let path_str = entry_path.to_string_lossy();
+
+        // Determine which scope this entry belongs to
+        let (target_root, should_import) = if path_str.starts_with("config/") || path_str == "config" {
+            (Some(&config_dir), import_config)
+        } else if path_str.starts_with("matches/") || path_str == "matches" {
+            (Some(&matches_dir), import_matches)
+        } else if path_str.starts_with("packages/") || path_str == "packages" {
+            (Some(&packages_dir), import_packages)
+        } else {
+            (None, false)
+        };
+
+        if !should_import || target_root.is_none() {
+            continue;
+        }
+
+        let target_root = target_root.unwrap();
+
+        // Strip the scope prefix from the path
+        let relative_path = strip_scope_prefix(&entry_path);
+
+        // Skip if this is just the scope root directory
+        if relative_path.as_os_str().is_empty() {
+            continue;
+        }
+
+        let target_path = target_root.join(&relative_path);
+
+        // Validate path doesn't escape target directory
+        if !target_path.starts_with(target_root) {
+            anyhow::bail!("path traversal attempt: {}", entry_path.display());
+        }
+
+        match entry.header().entry_type() {
+            EntryType::Directory => {
+                fs::create_dir_all(&target_path)
+                    .with_context(|| format!("failed to create directory: {}", target_path.display()))?;
+            }
+            EntryType::Regular => {
+                // Ensure parent directory exists
+                if let Some(parent) = target_path.parent() {
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("failed to create parent directory: {}", parent.display()))?;
+                }
+
+                let mut file_data = Vec::new();
+                entry.read_to_end(&mut file_data)
+                    .with_context(|| format!("failed to read archive entry: {}", entry_path.display()))?;
+
+                fs::write(&target_path, &file_data)
+                    .with_context(|| format!("failed to write file: {}", target_path.display()))?;
+            }
+            _ => {
+                // Skip other entry types (symlinks, etc.)
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn strip_scope_prefix(path: &Path) -> PathBuf {
+    let mut components = path.components();
+    // Skip the first component (the scope prefix: config, matches, or packages)
+    components.next();
+    components.as_path().to_path_buf()
+}
+
+fn clear_directory_except(root: &Path, preserve: Option<&Path>) -> Result<()> {
+    use std::fs;
+    use walkdir::WalkDir;
+
+    if !root.exists() {
+        return Ok(());
+    }
+
+    for entry in WalkDir::new(root).min_depth(1).contents_first(true) {
+        let entry = entry?;
+        let path = entry.path();
+
+        if let Some(preserve_path) = preserve {
+            if path.starts_with(preserve_path) {
+                continue;
+            }
+        }
+
+        if entry.file_type().is_dir() {
+            fs::remove_dir(path)?;
+        } else {
+            fs::remove_file(path)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn import_dialog_main(args: &ArgMatches, icon_paths: &IconPaths) -> i32 {
+    let config_path = args.value_of("config_path").expect("missing config_path");
+
+    // Set up the import context for the callbacks
+    {
+        let mut context = IMPORT_CONTEXT.lock().unwrap();
+        *context = Some(ImportContext {
+            config_path: PathBuf::from(config_path),
+        });
+    }
+
+    // Show the import dialog
+    espanso_modulo::import_dialog::show(
+        icon_paths.wizard_icon.as_ref().map(|p| p.to_string_lossy().to_string()).as_deref(),
+        validate_import_data_callback,
+        perform_import_callback,
+    );
+
+    // Clean up the context
+    {
+        let mut context = IMPORT_CONTEXT.lock().unwrap();
+        *context = None;
+    }
+
+    0
+}

--- a/espanso/src/cli/modulo/mod.rs
+++ b/espanso/src/cli/modulo/mod.rs
@@ -20,7 +20,11 @@
 use super::{CliModule, CliModuleArgs};
 
 #[cfg(feature = "modulo")]
+mod export_dialog;
+#[cfg(feature = "modulo")]
 mod form;
+#[cfg(feature = "modulo")]
+mod import_dialog;
 #[cfg(feature = "modulo")]
 mod search;
 #[cfg(feature = "modulo")]
@@ -47,6 +51,14 @@ fn modulo_main(args: CliModuleArgs) -> i32 {
     let cli_args = args.cli_args.expect("missing cli_args in modulo main");
     let icon_paths =
         crate::icon::load_icon_paths(&paths.runtime).expect("unable to load icon paths");
+
+    if let Some(matches) = cli_args.subcommand_matches("export_dialog") {
+        return export_dialog::export_dialog_main(matches, &icon_paths);
+    }
+
+    if let Some(matches) = cli_args.subcommand_matches("import_dialog") {
+        return import_dialog::import_dialog_main(matches, &icon_paths);
+    }
 
     if let Some(matches) = cli_args.subcommand_matches("form") {
         return form::form_main(matches, &icon_paths);

--- a/espanso/src/cli/offline.rs
+++ b/espanso/src/cli/offline.rs
@@ -1,0 +1,1440 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! Offline import/export functionality for Espanso configuration.
+//!
+//! This module provides commands to export Espanso configuration, matches,
+//! and packages as a base64-encoded payload for offline transfer between
+//! machines. The payload is compressed using gzip and encoded in base64
+//! for easy copy-paste or file transfer.
+//!
+//! # Usage
+//!
+//! ## Export Examples
+//!
+//! Export all data:
+//! ```bash
+//! espanso export > backup.txt
+//! ```
+//!
+//! Export specific scopes:
+//! ```bash
+//! espanso export --scope config,matches > backup.txt
+//! espanso export --scope packages > packages-only.txt
+//! ```
+//!
+//! Export with wrapped output (76 columns):
+//! ```bash
+//! espanso export --wrap 76 > backup.txt
+//! ```
+//!
+//! ## Import Examples
+//!
+//! Import data (interactive - prompts for confirmation):
+//! ```bash
+//! espanso import < backup.txt
+//! ```
+//!
+//! Import data (non-interactive - skips confirmation):
+//! ```bash
+//! espanso import --yes < backup.txt
+//! ```
+//!
+//! Import specific scopes:
+//! ```bash
+//! espanso import --scope config < config-backup.txt
+//! ```
+//!
+//! Import with line break conversion for YAML files:
+//! ```bash
+//! espanso import --convert-lb < backup.txt
+//! ```
+//!
+//! # Security
+//!
+//! - **Path traversal protection**: `sanitize_relative_path()` validates all paths
+//! - **Root boundary enforcement**: `ensure_inside_root()` prevents escaping target directories
+//! - **Atomic file writes**: `write_atomic()` prevents partial file corruption
+//! - **User confirmation**: Destructive operations require explicit confirmation (unless `--yes` flag is used)
+//!
+//! # Platform Support
+//!
+//! - **macOS**: Full support (interactive and non-interactive)
+//! - **Windows**: Full support (interactive and non-interactive)
+//! - **Linux**: Full support (interactive and non-interactive)
+//!
+//! ## Non-Interactive Environments
+//!
+//! When running in non-interactive environments (CI/CD, services, cron jobs, Docker),
+//! use the `--yes` flag to skip the confirmation prompt:
+//!
+//! ```bash
+//! espanso import --yes < backup.txt
+//! ```
+//!
+//! Without the `--yes` flag, the import command will attempt to read from:
+//! - Unix/macOS: `/dev/tty` (interactive) or `/dev/stdin` (piped input)
+//! - Windows: `CONIN$` (console input)
+//!
+//! If no input is available, a clear error message will guide you to use `--yes`.
+//!
+//! # Archive Format
+//!
+//! The export creates a tar.gz archive with the following structure:
+//! - `config/` - Configuration files from `~/.config/espanso/config/`
+//! - `matches/` - Match files from `~/.config/espanso/match/`
+//! - `packages/` - Package files from `~/.config/espanso/match/packages/`
+//!
+//! The archive is then gzip-compressed and base64-encoded for portability.
+
+use std::{
+    fs,
+    io::{self, Read, Write},
+    path::{Component, Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD, read::DecoderReader, write::EncoderWriter, Engine};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use tar::{Archive, Builder, EntryType};
+use walkdir::WalkDir;
+
+use super::{CliModule, CliModuleArgs};
+use crate::{error_eprintln, path::Paths};
+
+/// A reader adapter that filters out all ASCII whitespace characters.
+///
+/// This is used during import to handle base64 input that may contain
+/// newlines, spaces, or other whitespace for readability. The base64
+/// decoder requires a continuous stream of valid base64 characters.
+///
+/// # Implementation Details
+///
+/// - Uses an 8KB internal buffer for efficient reading
+/// - Filters spaces, tabs, newlines, carriage returns
+/// - Ensures at least one non-whitespace byte is returned per read
+/// - Returns 0 only when the underlying reader is exhausted
+struct WhitespaceFilteringReader<R> {
+    inner: R,
+}
+
+impl<R> WhitespaceFilteringReader<R> {
+    fn new(inner: R) -> Self {
+        Self { inner }
+    }
+}
+
+impl<R: Read> Read for WhitespaceFilteringReader<R> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+
+        let mut total = 0;
+        let mut buf = [0u8; 8192];
+
+        // Keep reading until we have at least one non-whitespace byte
+        // or the underlying reader is exhausted
+        while total == 0 {
+            let count = self.inner.read(&mut buf)?;
+            if count == 0 {
+                // Underlying reader exhausted
+                return Ok(0);
+            }
+
+            // Filter out whitespace and copy non-whitespace bytes to output
+            for &byte in &buf[..count] {
+                if byte.is_ascii_whitespace() {
+                    continue;
+                }
+                out[total] = byte;
+                total += 1;
+                if total == out.len() {
+                    // Output buffer full
+                    break;
+                }
+            }
+        }
+
+        Ok(total)
+    }
+}
+
+/// A writer adapter that wraps output at a specified column width.
+///
+/// This is used during export to make base64 output more readable
+/// by inserting newlines at regular intervals. This is particularly
+/// useful when the output will be displayed in email clients or
+/// text editors with fixed-width displays.
+///
+/// # Implementation Details
+///
+/// - Tracks current column position
+/// - Inserts newline when reaching wrap width
+/// - Resets column counter after each newline
+/// - Writes one byte at a time for precise column tracking
+struct WrapWriter<W> {
+    inner: W,
+    wrap: usize,
+    col: usize,
+}
+
+impl<W> WrapWriter<W> {
+    fn new(inner: W, wrap: usize) -> Self {
+        Self {
+            inner,
+            wrap,
+            col: 0,
+        }
+    }
+}
+
+impl<W: Write> Write for WrapWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut written = 0;
+        for &byte in buf {
+            self.inner.write_all(&[byte])?;
+            written += 1;
+            self.col += 1;
+            if self.col >= self.wrap {
+                self.inner.write_all(b"\n")?;
+                self.col = 0;
+            }
+        }
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Creates the CLI module for the export command.
+///
+/// Exports Espanso configuration data as a base64-encoded, gzip-compressed payload.
+/// The output is written to stdout and can be redirected to a file or piped to another command.
+///
+/// # Supported Scopes
+///
+/// - `config` - Configuration files from `~/.config/espanso/config/`
+/// - `matches` - Match files from `~/.config/espanso/match/`
+/// - `packages` - Package files from `~/.config/espanso/match/packages/`
+///
+/// # Examples
+///
+/// Export all data:
+/// ```bash
+/// espanso export > backup.txt
+/// ```
+///
+/// Export only configuration:
+/// ```bash
+/// espanso export --scope config > config-backup.txt
+/// ```
+///
+/// Export with wrapped output (useful for email or text editors):
+/// ```bash
+/// espanso export --wrap 76 > backup.txt
+/// ```
+///
+/// # Output Format
+///
+/// The output is a base64-encoded string representing a gzip-compressed tar archive.
+/// A final newline is added to make terminal display cleaner.
+pub fn new_export() -> CliModule {
+    CliModule {
+        requires_paths: true,
+        subcommand: "export".to_string(),
+        entry: export_main,
+        ..Default::default()
+    }
+}
+
+/// Creates the CLI module for the import command.
+///
+/// Imports Espanso configuration data from a base64-encoded payload (created by `export`).
+/// The input is read from stdin. This operation is **destructive** - it will delete
+/// existing data in the selected scopes before importing.
+///
+/// # Safety
+///
+/// - **Requires confirmation**: By default, prompts user for confirmation before proceeding
+/// - **Use `--yes` flag**: Skip confirmation in non-interactive environments (CI/CD, scripts)
+/// - **Atomic writes**: Files are written atomically to prevent corruption
+/// - **Path validation**: All paths are validated to prevent directory traversal attacks
+///
+/// # Supported Scopes
+///
+/// - `config` - Configuration files
+/// - `matches` - Match files (excluding packages if not selected)
+/// - `packages` - Package files
+///
+/// # Examples
+///
+/// Import with confirmation prompt:
+/// ```bash
+/// espanso import < backup.txt
+/// ```
+///
+/// Import without confirmation (for automation):
+/// ```bash
+/// espanso import --yes < backup.txt
+/// ```
+///
+/// Import only matches:
+/// ```bash
+/// espanso import --scope matches < matches-backup.txt
+/// ```
+///
+/// Import with line break conversion (Windows → Unix):
+/// ```bash
+/// espanso import --convert-lb < backup.txt
+/// ```
+///
+/// # Platform Notes
+///
+/// - **Unix/macOS**: Reads from `/dev/tty` or `/dev/stdin` for confirmation
+/// - **Windows**: Reads from `CONIN$` console input for confirmation
+/// - **Non-interactive**: Use `--yes` flag to skip confirmation in services, cron, Docker, CI/CD
+///
+/// # Errors
+///
+/// Returns detailed error messages including file paths when operations fail.
+/// Common errors include:
+/// - Permission denied
+/// - Disk full
+/// - Invalid archive format
+/// - Path traversal attempts
+pub fn new_import() -> CliModule {
+    CliModule {
+        requires_paths: true,
+        subcommand: "import".to_string(),
+        entry: import_main,
+        ..Default::default()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Scope {
+    Config,
+    Matches,
+    Packages,
+}
+
+impl Scope {
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "config" => Some(Scope::Config),
+            "matches" | "match" => Some(Scope::Matches),
+            "packages" => Some(Scope::Packages),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ScopeSelection {
+    config: bool,
+    matches: bool,
+    packages: bool,
+}
+
+impl ScopeSelection {
+    fn all() -> Self {
+        Self {
+            config: true,
+            matches: true,
+            packages: true,
+        }
+    }
+
+    fn is_empty(self) -> bool {
+        !self.config && !self.matches && !self.packages
+    }
+
+    fn includes(self, scope: Scope) -> bool {
+        match scope {
+            Scope::Config => self.config,
+            Scope::Matches => self.matches,
+            Scope::Packages => self.packages,
+        }
+    }
+}
+
+fn export_main(args: CliModuleArgs) -> i32 {
+    let paths = args.paths.expect("missing paths argument");
+    let cli_args = args.cli_args.expect("missing cli_args argument");
+    let sub_args = &cli_args;
+
+    let scope_selection = match parse_scope_selection(sub_args.value_of("scope")) {
+        Ok(scope) => scope,
+        Err(err) => {
+            error_eprintln!("invalid scope: {err}");
+            return 1;
+        }
+    };
+
+    let wrap = match parse_wrap_width(sub_args.value_of("wrap")) {
+        Ok(wrap) => wrap,
+        Err(err) => {
+            error_eprintln!("invalid wrap width: {err}");
+            return 1;
+        }
+    };
+
+    if let Err(err) = export_payload_to_stdout(&paths, scope_selection, wrap) {
+        error_eprintln!("unable to export: {err}");
+        return 1;
+    }
+
+    0
+}
+
+fn import_main(args: CliModuleArgs) -> i32 {
+    let mut paths = args.paths.expect("missing paths argument");
+    let cli_args = args.cli_args.expect("missing cli_args argument");
+    let sub_args = &cli_args;
+
+    // If espanso is running, use its config directory instead of the fallback logic
+    // This ensures import goes to the same location the running instance uses
+    if let Some(running_config) = get_running_espanso_config_path() {
+        if running_config != paths.config {
+            eprintln!(
+                "Note: Detected running espanso using config directory: {}",
+                running_config.display()
+            );
+            eprintln!(
+                "      Import will use this directory instead of: {}",
+                paths.config.display()
+            );
+            paths.config = running_config.clone();
+            paths.packages = running_config.join("match").join("packages");
+        }
+    }
+
+    let scope_selection = match parse_scope_selection(sub_args.value_of("scope")) {
+        Ok(scope) => scope,
+        Err(err) => {
+            error_eprintln!("invalid scope: {err}");
+            return 1;
+        }
+    };
+
+    let convert_lb = sub_args.is_present("convert-lb");
+    let skip_confirmation = sub_args.is_present("yes");
+
+    if let Err(err) = confirm_import(skip_confirmation) {
+        error_eprintln!("{err}");
+        return 1;
+    }
+
+    if let Err(err) = import_payload_from_stdin(&paths, scope_selection, convert_lb) {
+        error_eprintln!("unable to import: {err}");
+        return 1;
+    }
+
+    0
+}
+
+fn parse_scope_selection(value: Option<&str>) -> Result<ScopeSelection> {
+    let value = match value {
+        Some(value) => value.trim(),
+        None => return Ok(ScopeSelection::all()),
+    };
+
+    if value.is_empty() {
+        bail!("scope cannot be empty");
+    }
+
+    let mut selection = ScopeSelection::default();
+    for raw in value.split(',') {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let scope = Scope::from_str(trimmed).with_context(|| {
+            format!("unknown scope '{trimmed}', expected config,matches,packages")
+        })?;
+        match scope {
+            Scope::Config => selection.config = true,
+            Scope::Matches => selection.matches = true,
+            Scope::Packages => selection.packages = true,
+        }
+    }
+
+    if selection.is_empty() {
+        bail!("no valid scopes provided");
+    }
+
+    Ok(selection)
+}
+
+fn parse_wrap_width(value: Option<&str>) -> Result<Option<usize>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let parsed = value
+        .trim()
+        .parse::<usize>()
+        .context("wrap width must be a positive integer")?;
+    if parsed == 0 {
+        bail!("wrap width must be greater than zero");
+    }
+    Ok(Some(parsed))
+}
+
+/// Core archive building logic shared between export functions.
+///
+/// Builds a tar archive containing the selected scopes from the given paths.
+/// The archive is written to the provided writer, which is typically wrapped
+/// in gzip compression and base64 encoding.
+///
+/// # Arguments
+///
+/// * `writer` - The writer to output the tar archive to (typically gzip-compressed)
+/// * `paths` - The Espanso paths configuration
+/// * `selection` - Which scopes to include in the archive
+///
+/// # Implementation Details
+///
+/// Handles the special case where packages are nested inside the matches directory
+/// (default configuration). In this case, packages are skipped when exporting matches
+/// to avoid duplication, since they'll be exported separately if the packages scope
+/// is selected.
+fn build_archive<W: Write>(writer: W, paths: &Paths, selection: ScopeSelection) -> Result<()> {
+    let mut builder = Builder::new(writer);
+
+    let matches_dir = paths.config.join("match");
+    let packages_dir = paths.packages.clone();
+
+    // Check if packages directory is nested inside matches directory.
+    // This happens with the default configuration where packages are stored
+    // at config/match/packages. In this case, we need to skip the packages
+    // directory when exporting matches to avoid duplication, since packages
+    // will be exported separately if the packages scope is selected.
+    let matches_skip_packages =
+        matches_dir.is_dir() && packages_dir.is_dir() && packages_dir.starts_with(&matches_dir);
+
+    if selection.config {
+        let config_dir = paths.config.join("config");
+        append_dir_to_archive(&mut builder, &config_dir, Path::new("config"), None)?;
+    }
+    if selection.matches {
+        let skip_dir = if matches_skip_packages {
+            Some(packages_dir.as_path())
+        } else {
+            None
+        };
+        append_dir_to_archive(&mut builder, &matches_dir, Path::new("matches"), skip_dir)?;
+    }
+    if selection.packages {
+        append_dir_to_archive(&mut builder, &packages_dir, Path::new("packages"), None)?;
+    }
+
+    builder.finish()?;
+    Ok(())
+}
+
+fn export_payload_to_stdout(
+    paths: &Paths,
+    selection: ScopeSelection,
+    wrap: Option<usize>,
+) -> Result<()> {
+    let stdout = io::stdout();
+    let handle = stdout.lock();
+    let writer: Box<dyn Write + '_> = if let Some(width) = wrap {
+        Box::new(WrapWriter::new(handle, width))
+    } else {
+        Box::new(handle)
+    };
+    let encoder = EncoderWriter::new(writer, &STANDARD);
+    let mut gzip = GzEncoder::new(encoder, Compression::default());
+
+    build_archive(&mut gzip, paths, selection)?;
+
+    let mut encoder = gzip.finish()?;
+    let mut handle = encoder.finish()?;
+    handle.write_all(b"\n")?;
+    Ok(())
+}
+
+fn append_dir_to_archive<W: Write>(
+    builder: &mut Builder<W>,
+    source_dir: &Path,
+    archive_prefix: &Path,
+    skip_dir: Option<&Path>,
+) -> Result<()> {
+    if !source_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in WalkDir::new(source_dir).follow_links(false) {
+        let entry = entry?;
+        let path = entry.path();
+
+        if let Some(skip) = skip_dir {
+            if path.starts_with(skip) {
+                continue;
+            }
+        }
+
+        let relative = path
+            .strip_prefix(source_dir)
+            .context("unable to compute relative archive path")?;
+
+        let archive_path = if relative.as_os_str().is_empty() {
+            archive_prefix.to_path_buf()
+        } else {
+            archive_prefix.join(relative)
+        };
+
+        if entry.file_type().is_dir() {
+            builder.append_dir(&archive_path, path)?;
+        } else if entry.file_type().is_file() {
+            builder.append_path_with_name(path, &archive_path)?;
+        }
+        // Skip symlinks and other special file types to avoid tar format errors
+    }
+
+    Ok(())
+}
+
+fn confirm_import(skip_confirmation: bool) -> Result<()> {
+    if skip_confirmation {
+        return Ok(());
+    }
+
+    let prompt =
+        "This will DELETE your existing Espanso data for the selected scope(s) and replace it. Continue? [y/N] ";
+    eprint!("{prompt}");
+    let _ = io::stderr().flush();
+
+    loop {
+        let byte = read_confirmation_byte()?;
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+        return confirm_import_from_byte(byte);
+    }
+}
+
+fn confirm_import_from_byte(byte: u8) -> Result<()> {
+    if matches!(byte, b'y' | b'Y') {
+        return Ok(());
+    }
+    if matches!(byte, b'n' | b'N') {
+        bail!("aborted by user");
+    }
+    bail!("invalid confirmation input");
+}
+
+fn read_confirmation_byte() -> Result<u8> {
+    #[cfg(unix)]
+    {
+        read_confirmation_byte_unix()
+    }
+
+    #[cfg(windows)]
+    {
+        read_confirmation_byte_windows()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        bail!("unsupported platform")
+    }
+}
+
+/// Reads a single confirmation byte from the user on Unix/macOS systems.
+///
+/// # Platform-Specific Behavior
+///
+/// This function attempts to read from `/dev/tty` first (the controlling terminal),
+/// which allows interactive input even when stdin is redirected. If `/dev/tty` is
+/// not available (e.g., in Docker, CI/CD, cron jobs), it falls back to `/dev/stdin`.
+///
+/// The terminal is temporarily set to raw mode (no line buffering, no echo) to read
+/// a single character without requiring Enter. The original terminal settings are
+/// restored via a Drop guard, ensuring cleanup even on panic.
+///
+/// # Supported Environments
+///
+/// - ✅ Interactive terminal (TTY available)
+/// - ✅ Piped input: `echo "y" | espanso import < data.txt`
+/// - ✅ Docker containers without TTY
+/// - ✅ CI/CD pipelines
+/// - ✅ Cron jobs
+/// - ✅ SSH without TTY allocation
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Both `/dev/tty` and `/dev/stdin` are unavailable
+/// - Terminal settings cannot be modified (permission issues)
+/// - Read operation fails
+#[cfg(unix)]
+fn read_confirmation_byte_unix() -> Result<u8> {
+    use std::mem;
+    use std::os::unix::io::AsRawFd;
+
+    // Try /dev/tty first for interactive terminal, fallback to /dev/stdin for piped input
+    // This allows the command to work in non-interactive environments like cron, Docker, CI/CD
+    let mut file = fs::File::open("/dev/tty").or_else(|_| {
+        // If no TTY available, try stdin as fallback
+        // This enables piped input: echo "y" | espanso import < data.txt
+        fs::File::open("/dev/stdin")
+    })?;
+    let fd = file.as_raw_fd();
+    let mut termios: libc::termios = unsafe { mem::zeroed() };
+    if unsafe { libc::tcgetattr(fd, &mut termios) } != 0 {
+        return Err(io::Error::last_os_error().into());
+    }
+    let original = termios;
+    termios.c_lflag &= !(libc::ICANON | libc::ECHO);
+    termios.c_cc[libc::VMIN] = 1;
+    termios.c_cc[libc::VTIME] = 0;
+    if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &termios) } != 0 {
+        return Err(io::Error::last_os_error().into());
+    }
+
+    struct TermiosGuard {
+        fd: i32,
+        original: libc::termios,
+    }
+
+    impl Drop for TermiosGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = libc::tcsetattr(self.fd, libc::TCSANOW, &self.original);
+            }
+        }
+    }
+
+    let _guard = TermiosGuard { fd, original };
+    let mut buf = [0u8; 1];
+    file.read_exact(&mut buf)?;
+    Ok(buf[0])
+}
+
+/// Reads a single confirmation byte from the user on Windows systems.
+///
+/// # Platform-Specific Behavior
+///
+/// This function attempts to open the Windows console input device (`CONIN$`).
+/// If that fails, it tries to attach to the parent process's console and retry.
+/// This handles cases where the process was started without a console.
+///
+/// The console is temporarily set to raw mode (no line buffering, no echo) to read
+/// a single character without requiring Enter. The original console mode is
+/// restored via a Drop guard, ensuring cleanup even on panic.
+///
+/// # Supported Environments
+///
+/// - ✅ Interactive CMD/PowerShell
+/// - ✅ Windows Terminal
+/// - ⚠️ Windows Services: Requires `--yes` flag (no console available)
+/// - ⚠️ Scheduled Tasks: Requires `--yes` flag (no console available)
+///
+/// # Error Handling
+///
+/// If no console is available (service/scheduled task mode), returns a clear
+/// error message instructing the user to use the `--yes` flag for non-interactive mode.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Console input device cannot be opened (service mode)
+/// - Console mode cannot be modified (permission issues)
+/// - Read operation fails
+#[cfg(windows)]
+fn read_confirmation_byte_windows() -> Result<u8> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::Console::{
+        GetConsoleMode, ReadConsoleA, SetConsoleMode, CONSOLE_MODE, ENABLE_ECHO_INPUT,
+        ENABLE_LINE_INPUT,
+    };
+
+    // Try to open console input
+    // First attempt: CONIN$ (standard console input)
+    // Second attempt: attach to parent console and retry
+    // If both fail, we're likely running as a service or in non-interactive mode
+    let file = fs::File::open("CONIN$")
+        .or_else(|_| {
+            let _ = crate::util::attach_console();
+            fs::File::open("CONIN$")
+        })
+        .context("No console available. Running in non-interactive mode (service/scheduled task). Use --yes flag to skip confirmation.")?;
+    let handle = HANDLE(file.as_raw_handle());
+    let mut mode = CONSOLE_MODE::default();
+    unsafe { GetConsoleMode(handle, &mut mode)? };
+    let raw_mode = CONSOLE_MODE(mode.0 & !(ENABLE_LINE_INPUT.0 | ENABLE_ECHO_INPUT.0));
+    unsafe { SetConsoleMode(handle, raw_mode)? };
+
+    struct ConsoleModeGuard {
+        handle: HANDLE,
+        mode: CONSOLE_MODE,
+    }
+
+    impl Drop for ConsoleModeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = SetConsoleMode(self.handle, self.mode);
+            }
+        }
+    }
+
+    let _guard = ConsoleModeGuard { handle, mode };
+    let mut buf = [0u8; 1];
+    let mut read = 0u32;
+    unsafe {
+        ReadConsoleA(handle, buf.as_mut_ptr().cast(), 1, &mut read, None)?;
+    }
+    if read == 0 {
+        bail!("unable to read confirmation prompt");
+    }
+    Ok(buf[0])
+}
+
+fn import_payload_from_stdin(
+    paths: &Paths,
+    selection: ScopeSelection,
+    convert_lb: bool,
+) -> Result<()> {
+    // Read all input and filter whitespace before decoding
+    // This avoids issues with streaming readers and base64 padding
+    let stdin = io::stdin();
+    let mut handle = stdin.lock();
+    let mut input = String::new();
+    handle
+        .read_to_string(&mut input)
+        .context("failed to read input from stdin")?;
+
+    // Remove all whitespace from base64 input
+    let filtered: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+
+    let decoder = DecoderReader::new(filtered.as_bytes(), &STANDARD);
+    let gzip = GzDecoder::new(decoder);
+    let mut archive = Archive::new(gzip);
+
+    prepare_import_targets(paths, selection)?;
+
+    for entry in archive.entries()? {
+        let mut entry = entry.context("failed to get archive entry")?;
+        let entry_path = entry
+            .path()
+            .context("failed to read entry path")?
+            .to_path_buf();
+        let normalized = sanitize_relative_path(&entry_path)
+            .with_context(|| format!("invalid path in archive: {}", entry_path.display()))?;
+        let (scope, scope_relative) = split_scope_path(&normalized)
+            .with_context(|| format!("invalid scope in path: {}", entry_path.display()))?;
+
+        if !selection.includes(scope) {
+            continue;
+        }
+
+        let target_root = scope_root(paths, scope);
+        let target_path = target_root.join(&scope_relative);
+        ensure_inside_root(&target_root, &target_path)
+            .with_context(|| format!("path escapes target directory: {}", entry_path.display()))?;
+
+        match entry.header().entry_type() {
+            EntryType::Directory => {
+                fs::create_dir_all(&target_path).with_context(|| {
+                    format!("failed to create directory: {}", target_path.display())
+                })?;
+            }
+            EntryType::Regular => {
+                // Ensure parent directory exists before writing file
+                if let Some(parent) = target_path.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("failed to create parent directory: {}", parent.display())
+                    })?;
+                }
+                let mut data = Vec::new();
+                let bytes_read = entry.read_to_end(&mut data).with_context(|| {
+                    format!(
+                        "failed to read {} bytes from archive entry: {}",
+                        entry.size(),
+                        entry_path.display()
+                    )
+                })?;
+
+                if bytes_read != entry.size() as usize {
+                    bail!(
+                        "incomplete read: expected {} bytes, got {} bytes for {}",
+                        entry.size(),
+                        bytes_read,
+                        entry_path.display()
+                    );
+                }
+
+                let data = maybe_convert_line_breaks(&target_path, data, convert_lb)?;
+                write_atomic(&target_path, &data)
+                    .with_context(|| format!("failed to import file: {}", target_path.display()))?;
+            }
+            _ => {
+                bail!(
+                    "unsupported archive entry type {:?} for {}",
+                    entry.header().entry_type(),
+                    entry_path.display()
+                );
+            }
+        }
+    }
+
+    // Import complete - espanso service will auto-detect config changes
+    Ok(())
+}
+
+fn prepare_import_targets(paths: &Paths, selection: ScopeSelection) -> Result<()> {
+    if selection.config {
+        let config_dir = paths.config.join("config");
+        delete_tree(&config_dir)?;
+        fs::create_dir_all(&config_dir)?;
+    }
+
+    if selection.matches {
+        let matches_dir = paths.config.join("match");
+        let packages_dir = paths.packages.clone();
+        if packages_dir.starts_with(&matches_dir) && !selection.packages {
+            clear_directory_except(&matches_dir, Some(&packages_dir))?;
+        } else {
+            delete_tree(&matches_dir)?;
+            fs::create_dir_all(&matches_dir)?;
+        }
+    }
+
+    if selection.packages {
+        let packages_dir = paths.packages.clone();
+        delete_tree(&packages_dir)?;
+        fs::create_dir_all(&packages_dir)?;
+    }
+
+    Ok(())
+}
+
+fn delete_tree(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if path.is_file() {
+        fs::remove_file(path)?;
+    } else {
+        fs::remove_dir_all(path)?;
+    }
+    Ok(())
+}
+
+fn clear_directory_except(root: &Path, preserve: Option<&Path>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+
+    for entry in WalkDir::new(root).min_depth(1).contents_first(true) {
+        let entry = entry?;
+        let path = entry.path();
+
+        if let Some(preserve_path) = preserve {
+            if path.starts_with(preserve_path) {
+                continue;
+            }
+        }
+
+        if entry.file_type().is_dir() {
+            fs::remove_dir(path)?;
+        } else {
+            fs::remove_file(path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn sanitize_relative_path(path: &Path) -> Result<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                bail!("absolute paths are not allowed in archives")
+            }
+            Component::ParentDir => bail!("path traversal is not allowed in archives"),
+            Component::CurDir => {}
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        bail!("empty path entry in archive");
+    }
+
+    Ok(normalized)
+}
+
+fn split_scope_path(path: &Path) -> Result<(Scope, PathBuf)> {
+    let mut components = path.components();
+    let prefix = components
+        .next()
+        .context("archive entry missing scope prefix")?;
+
+    let scope = match prefix {
+        Component::Normal(name) => {
+            let name = name.to_string_lossy();
+            Scope::from_str(&name).with_context(|| format!("unknown scope prefix '{name}'"))?
+        }
+        _ => bail!("invalid scope prefix in archive entry"),
+    };
+
+    let mut remainder = PathBuf::new();
+    for component in components {
+        match component {
+            Component::Normal(part) => remainder.push(part),
+            _ => bail!("invalid archive entry path"),
+        }
+    }
+
+    Ok((scope, remainder))
+}
+
+fn scope_root(paths: &Paths, scope: Scope) -> PathBuf {
+    match scope {
+        Scope::Config => paths.config.join("config"),
+        Scope::Matches => paths.config.join("match"),
+        Scope::Packages => paths.packages.clone(),
+    }
+}
+
+fn ensure_inside_root(root: &Path, target: &Path) -> Result<()> {
+    if !target.starts_with(root) {
+        bail!("archive entry resolved outside target directory");
+    }
+    Ok(())
+}
+
+fn maybe_convert_line_breaks(path: &Path, data: Vec<u8>, convert: bool) -> Result<Vec<u8>> {
+    if !convert || !is_yaml_path(path) {
+        return Ok(data);
+    }
+
+    let text = match std::str::from_utf8(&data) {
+        Ok(text) => text,
+        Err(_) => {
+            eprintln!(
+                "warning: skipping line break conversion for non-UTF8 YAML file {}",
+                path.display()
+            );
+            return Ok(data);
+        }
+    };
+
+    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    Ok(normalized.into_bytes())
+}
+
+fn is_yaml_path(path: &Path) -> bool {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some(ext) => {
+            let lower = ext.to_ascii_lowercase();
+            lower == "yml" || lower == "yaml"
+        }
+        None => false,
+    }
+}
+
+fn write_atomic(path: &Path, data: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create parent directory: {}", parent.display()))?;
+    }
+
+    let tmp_path = temp_path_for(path);
+
+    // Guard to ensure temp file cleanup on error
+    struct TempFileGuard {
+        path: PathBuf,
+        cleanup: bool,
+    }
+
+    impl Drop for TempFileGuard {
+        fn drop(&mut self) {
+            if self.cleanup {
+                let _ = fs::remove_file(&self.path);
+            }
+        }
+    }
+
+    let mut guard = TempFileGuard {
+        path: tmp_path.clone(),
+        cleanup: true,
+    };
+
+    {
+        let mut file = fs::File::create(&tmp_path)
+            .with_context(|| format!("failed to create temporary file: {}", tmp_path.display()))?;
+        file.write_all(data).with_context(|| {
+            format!("failed to write to temporary file: {}", tmp_path.display())
+        })?;
+        file.sync_all()
+            .with_context(|| format!("failed to sync temporary file: {}", tmp_path.display()))?;
+    }
+
+    if path.exists() {
+        fs::remove_file(path)
+            .with_context(|| format!("failed to remove existing file: {}", path.display()))?;
+    }
+
+    fs::rename(&tmp_path, path)
+        .with_context(|| format!("failed to rename temporary file to: {}", path.display()))?;
+
+    // Prevent cleanup on success
+    guard.cleanup = false;
+
+    Ok(())
+}
+
+fn temp_path_for(path: &Path) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let pid = std::process::id();
+    let extension = format!("espanso_import_tmp_{pid}_{unique}");
+    path.with_extension(extension)
+}
+
+/// Attempts to get the config path from a running espanso instance.
+/// Returns None if espanso is not running or if the path cannot be determined.
+fn get_running_espanso_config_path() -> Option<PathBuf> {
+    let espanso_exe_path = std::env::current_exe().ok()?;
+    let output = Command::new(espanso_exe_path.to_string_lossy().to_string())
+        .args(["path"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    for line in stdout.lines() {
+        if let Some(path_str) = line.strip_prefix("Config: ") {
+            return Some(PathBuf::from(path_str.trim()));
+        }
+    }
+    None
+}
+
+pub fn export_config_to_string(
+    runtime_dir: &Path,
+    config_dir: &Path,
+    export_config: bool,
+    export_matches: bool,
+    export_packages: bool,
+) -> Result<String> {
+    let paths = Paths {
+        runtime: runtime_dir.to_path_buf(),
+        config: config_dir.to_path_buf(),
+        packages: config_dir.join("match").join("packages"),
+        is_portable_mode: false,
+    };
+    
+    let selection = ScopeSelection {
+        config: export_config,
+        matches: export_matches,
+        packages: export_packages,
+    };
+    
+    let bytes = export_to_vec(&paths, selection)?;
+    // bytes is already base64-encoded (export_to_vec writes through EncoderWriter)
+    // so just convert to String
+    String::from_utf8(bytes).context("export produced invalid UTF-8")
+}
+
+fn export_to_vec(paths: &Paths, selection: ScopeSelection) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    {
+        let encoder = EncoderWriter::new(&mut output, &STANDARD);
+        let mut gzip = GzEncoder::new(encoder, Compression::default());
+
+        // Use the shared build_archive function to eliminate duplication
+        build_archive(&mut gzip, paths, selection)?;
+
+        let mut encoder = gzip.finish()?;
+        encoder.finish()?;
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempdir::TempDir;
+
+    fn create_sample_tree(base: &Path) -> Result<Paths> {
+        let config_root = base.join("config_root");
+        let runtime_root = base.join("runtime");
+        let packages_root = config_root.join("match").join("packages");
+
+        fs::create_dir_all(config_root.join("config"))?;
+        fs::create_dir_all(config_root.join("match"))?;
+        fs::create_dir_all(&packages_root)?;
+
+        fs::write(config_root.join("config").join("default.yml"), "config")?;
+        fs::write(config_root.join("match").join("base.yml"), "matches")?;
+        fs::write(packages_root.join("package.yml"), "packages")?;
+
+        Ok(Paths {
+            config: config_root,
+            runtime: runtime_root,
+            packages: packages_root,
+            is_portable_mode: false,
+        })
+    }
+
+    fn import_from_bytes(
+        payload: &[u8],
+        paths: &Paths,
+        selection: ScopeSelection,
+        convert_lb: bool,
+    ) -> Result<()> {
+        let decoder = DecoderReader::new(payload, &STANDARD);
+        let gzip = GzDecoder::new(decoder);
+        let mut archive = Archive::new(gzip);
+
+        prepare_import_targets(paths, selection)?;
+
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+            let entry_path = entry.path()?.to_path_buf();
+            let normalized = sanitize_relative_path(&entry_path)?;
+            let (scope, scope_relative) = split_scope_path(&normalized)?;
+
+            if !selection.includes(scope) {
+                continue;
+            }
+
+            let target_root = scope_root(paths, scope);
+            let target_path = target_root.join(&scope_relative);
+            ensure_inside_root(&target_root, &target_path)?;
+
+            match entry.header().entry_type() {
+                EntryType::Directory => {
+                    fs::create_dir_all(&target_path)?;
+                }
+                EntryType::Regular => {
+                    let mut data = Vec::new();
+                    entry.read_to_end(&mut data)?;
+                    let data = maybe_convert_line_breaks(&target_path, data, convert_lb)?;
+                    write_atomic(&target_path, &data)?;
+                }
+                _ => {
+                    bail!(
+                        "unsupported archive entry type for {}",
+                        entry_path.display()
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip_scopes() -> Result<()> {
+        let temp = TempDir::new("espanso-offline")?;
+        let paths = create_sample_tree(temp.path())?;
+
+        let scopes = [
+            ScopeSelection {
+                config: true,
+                matches: false,
+                packages: false,
+            },
+            ScopeSelection {
+                config: false,
+                matches: true,
+                packages: false,
+            },
+            ScopeSelection {
+                config: false,
+                matches: false,
+                packages: true,
+            },
+            ScopeSelection::all(),
+        ];
+
+        for scope in scopes {
+            let payload = export_to_vec(&paths, scope)?;
+
+            let dest = TempDir::new("espanso-offline-dest")?;
+            let dest_paths = create_sample_tree(dest.path())?;
+            fs::write(dest_paths.config.join("config").join("default.yml"), "old")?;
+            fs::write(dest_paths.config.join("match").join("base.yml"), "old")?;
+            fs::write(dest_paths.packages.join("package.yml"), "old")?;
+
+            import_from_bytes(&payload, &dest_paths, scope, false)?;
+
+            if scope.config {
+                assert_eq!(
+                    fs::read_to_string(dest_paths.config.join("config").join("default.yml"))?,
+                    "config"
+                );
+            } else {
+                assert_eq!(
+                    fs::read_to_string(dest_paths.config.join("config").join("default.yml"))?,
+                    "old"
+                );
+            }
+
+            if scope.matches {
+                assert_eq!(
+                    fs::read_to_string(dest_paths.config.join("match").join("base.yml"))?,
+                    "matches"
+                );
+            } else {
+                assert_eq!(
+                    fs::read_to_string(dest_paths.config.join("match").join("base.yml"))?,
+                    "old"
+                );
+            }
+
+            if scope.packages {
+                assert_eq!(
+                    fs::read_to_string(dest_paths.packages.join("package.yml"))?,
+                    "packages"
+                );
+            } else {
+                assert_eq!(
+                    fs::read_to_string(dest_paths.packages.join("package.yml"))?,
+                    "old"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn import_accepts_legacy_match_scope_prefix() -> Result<()> {
+        let (scope, remainder) = split_scope_path(Path::new("match/base.yml"))?;
+        assert_eq!(scope, Scope::Matches);
+        assert_eq!(remainder, PathBuf::from("base.yml"));
+        Ok(())
+    }
+
+    #[test]
+    fn whitespace_filtering_reader_strips_whitespace() -> Result<()> {
+        let input = b"a b\nc\t";
+        let mut reader = WhitespaceFilteringReader::new(&input[..]);
+        let mut output = String::new();
+        reader.read_to_string(&mut output)?;
+        assert_eq!(output, "abc");
+        Ok(())
+    }
+
+    #[test]
+    fn import_aborts_without_confirmation() -> Result<()> {
+        let result = confirm_import_from_byte(b'n');
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_path_traversal() -> Result<()> {
+        let mut raw = Vec::new();
+        {
+            let mut builder = Builder::new(&mut raw);
+            let mut header = tar::Header::new_gnu();
+            let name = b"matches/../evil";
+            let old = header.as_old_mut();
+            old.name = [0; 100];
+            old.name[..name.len()].copy_from_slice(name);
+            header.set_entry_type(EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_size(4);
+            header.set_cksum();
+            builder.append(&header, "evil".as_bytes())?;
+            builder.finish()?;
+        }
+
+        let mut gzipped = Vec::new();
+        {
+            let mut gzip = GzEncoder::new(&mut gzipped, Compression::default());
+            gzip.write_all(&raw)?;
+            gzip.finish()?;
+        }
+
+        let mut encoded = Vec::new();
+        {
+            let mut encoder = EncoderWriter::new(&mut encoded, &STANDARD);
+            encoder.write_all(&gzipped)?;
+            encoder.finish()?;
+        }
+
+        let temp = TempDir::new("espanso-offline")?;
+        let paths = create_sample_tree(temp.path())?;
+        let result = import_from_bytes(&encoded, &paths, ScopeSelection::all(), false);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn convert_line_breaks_for_yaml_only() -> Result<()> {
+        let temp = TempDir::new("espanso-offline")?;
+        let paths = create_sample_tree(temp.path())?;
+
+        let yaml_path = paths.config.join("config").join("default.yml");
+        let txt_path = paths.config.join("config").join("notes.txt");
+        fs::write(&yaml_path, "line1\r\nline2\rline3")?;
+        fs::write(&txt_path, "keep\r\nas-is")?;
+
+        let payload = export_to_vec(
+            &paths,
+            ScopeSelection {
+                config: true,
+                matches: false,
+                packages: false,
+            },
+        )?;
+
+        let dest = TempDir::new("espanso-offline-dest")?;
+        let dest_paths = create_sample_tree(dest.path())?;
+        import_from_bytes(
+            &payload,
+            &dest_paths,
+            ScopeSelection {
+                config: true,
+                matches: false,
+                packages: false,
+            },
+            true,
+        )?;
+
+        let yaml_result = fs::read_to_string(dest_paths.config.join("config").join("default.yml"))?;
+        let txt_result = fs::read_to_string(dest_paths.config.join("config").join("notes.txt"))?;
+        assert_eq!(yaml_result, "line1\nline2\nline3");
+        assert_eq!(txt_result, "keep\r\nas-is");
+
+        Ok(())
+    }
+}

--- a/espanso/src/cli/service/macos.rs
+++ b/espanso/src/cli/service/macos.rs
@@ -18,7 +18,7 @@
  */
 
 use anyhow::{bail, Result};
-use log::{error, info, warn};
+use log::{info, warn};
 use std::process::Command;
 use std::{fs::create_dir_all, process::ExitStatus};
 use thiserror::Error;

--- a/espanso/src/cli/worker/builtin/config_transfer.rs
+++ b/espanso/src/cli/worker/builtin/config_transfer.rs
@@ -1,0 +1,50 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use espanso_engine::event::EventType;
+
+use crate::cli::worker::builtin::generate_next_builtin_id;
+
+use super::BuiltInMatch;
+
+pub fn create_match_export_config() -> BuiltInMatch {
+    BuiltInMatch {
+        id: generate_next_builtin_id(),
+        label: "Export config",
+        triggers: Vec::new(),
+        action: |_context| {
+            // TODO: Launch export dialog via modulo
+            EventType::NOOP
+        },
+        ..Default::default()
+    }
+}
+
+pub fn create_match_import_config() -> BuiltInMatch {
+    BuiltInMatch {
+        id: generate_next_builtin_id(),
+        label: "Import config",
+        triggers: Vec::new(),
+        action: |_context| {
+            // TODO: Launch import dialog via modulo
+            EventType::NOOP
+        },
+        ..Default::default()
+    }
+}

--- a/espanso/src/cli/worker/builtin/mod.rs
+++ b/espanso/src/cli/worker/builtin/mod.rs
@@ -25,6 +25,7 @@ use espanso_engine::event::EventType;
 
 use super::context::Context;
 
+mod config_transfer;
 mod debug;
 mod process;
 mod search;
@@ -58,6 +59,8 @@ pub fn get_builtin_matches(config: &dyn Config) -> Vec<BuiltInMatch> {
         debug::create_match_show_active_config_info(),
         debug::create_match_show_active_app_info(),
         debug::create_match_show_logs(),
+        config_transfer::create_match_export_config(),
+        config_transfer::create_match_import_config(),
         process::create_match_exit(),
         process::create_match_restart(),
     ];

--- a/espanso/src/cli/worker/engine/dispatch/executor/export_import.rs
+++ b/espanso/src/cli/worker/engine/dispatch/executor/export_import.rs
@@ -1,0 +1,107 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::gui::modulo::manager::ModuloManager;
+use crate::gui::FormUI;
+use crate::path::Paths;
+use espanso_engine::dispatch::ExportImportHandler;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::sync::Mutex;
+
+// Global state to pass paths to the C callback
+static EXPORT_CONTEXT: Mutex<Option<ExportContext>> = Mutex::new(None);
+
+struct ExportContext {
+    runtime_path: String,
+    config_path: String,
+}
+
+pub struct ExportImportHandlerAdapter<'a> {
+    modulo_manager: &'a ModuloManager,
+    form_ui: &'a dyn FormUI,
+    paths: &'a Paths,
+}
+
+impl<'a> ExportImportHandlerAdapter<'a> {
+    pub fn new(modulo_manager: &'a ModuloManager, form_ui: &'a dyn FormUI, paths: &'a Paths) -> Self {
+        Self {
+            modulo_manager,
+            form_ui,
+            paths,
+        }
+    }
+}
+
+extern "C" fn generate_export_code_callback(
+    export_config: std::os::raw::c_int,
+    export_matches: std::os::raw::c_int,
+    export_packages: std::os::raw::c_int,
+) -> *const c_char {
+    let context = EXPORT_CONTEXT.lock().unwrap();
+    if let Some(ctx) = context.as_ref() {
+        match crate::cli::offline::export_config_to_string(
+            &std::path::PathBuf::from(&ctx.runtime_path),
+            &std::path::PathBuf::from(&ctx.config_path),
+            export_config != 0,
+            export_matches != 0,
+            export_packages != 0,
+        ) {
+            Ok(export_code) => {
+                let c_string = CString::new(export_code).unwrap_or_else(|_| CString::new("Error: Invalid export code").unwrap());
+                c_string.into_raw()
+            }
+            Err(err) => {
+                let error_msg = format!("Error: {}", err);
+                let c_string = CString::new(error_msg).unwrap_or_else(|_| CString::new("Error generating export code").unwrap());
+                c_string.into_raw()
+            }
+        }
+    } else {
+        let c_string = CString::new("Error: Export context not initialized").unwrap();
+        c_string.into_raw()
+    }
+}
+
+impl ExportImportHandler for ExportImportHandlerAdapter<'_> {
+    fn handle_export(&self) -> anyhow::Result<()> {
+        let runtime_path = self.paths.runtime.to_string_lossy().to_string();
+        let config_path = self.paths.config.to_string_lossy().to_string();
+        
+        // Show the export dialog with paths passed as arguments (spawned as separate process)
+        self.modulo_manager.spawn(
+            &["export_dialog", "--runtime-path", &runtime_path, "--config-path", &config_path],
+            ""
+        )?;
+
+        Ok(())
+    }
+
+    fn handle_import(&self) -> anyhow::Result<()> {
+        let config_path = self.paths.config.to_string_lossy().to_string();
+
+        // Show the import dialog (spawned as separate process)
+        self.modulo_manager.spawn(
+            &["import_dialog", "--config-path", &config_path],
+            ""
+        )?;
+
+        Ok(())
+    }
+}

--- a/espanso/src/cli/worker/engine/dispatch/executor/mod.rs
+++ b/espanso/src/cli/worker/engine/dispatch/executor/mod.rs
@@ -20,6 +20,7 @@
 pub mod clipboard_injector;
 pub mod context_menu;
 pub mod event_injector;
+pub mod export_import;
 pub mod icon;
 pub mod key_injector;
 pub mod secure_input;

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -262,6 +262,7 @@ pub fn initialize_and_spawn(
             let icon_adapter = IconHandlerAdapter::new(&*ui_remote);
             let secure_input_adapter = SecureInputManagerAdapter::new();
             let text_ui_adapter = TextUIHandlerAdapter::new(&modulo_text_ui, &paths);
+            let export_import_adapter = dispatch::executor::export_import::ExportImportHandlerAdapter::new(&modulo_manager, &modulo_form_ui, &paths);
             let dispatcher = espanso_engine::dispatch::default(
                 &event_injector,
                 &clipboard_injector,
@@ -273,6 +274,7 @@ pub fn initialize_and_spawn(
                 &icon_adapter,
                 &secure_input_adapter,
                 &text_ui_adapter,
+                &export_import_adapter,
             );
 
             // Disable previously granted linux capabilities if not needed anymore

--- a/espanso/src/gui/mod.rs
+++ b/espanso/src/gui/mod.rs
@@ -59,6 +59,9 @@ pub enum FormField {
         values: Vec<String>,
         separator: String,
     },
+    Checkbox {
+        default: bool,
+    },
 }
 
 pub trait TextUI {

--- a/espanso/src/gui/modulo/form.rs
+++ b/espanso/src/gui/modulo/form.rs
@@ -123,6 +123,10 @@ fn convert_fields_into_object(fields: &HashMap<String, FormField>) -> Map<String
               "values": values,
               "separator": separator,
             }),
+            FormField::Checkbox { default } => json!({
+              "type": "checkbox",
+              "default": if *default { "true" } else { "false" },
+            }),
         };
         obj.insert(name.clone(), value);
     }

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -75,6 +75,8 @@ static CLI_HANDLERS: LazyLock<Vec<CliModule>> = LazyLock::new(|| {
         cli::package::new(),
         cli::match_cli::new(),
         cli::cmd::new(),
+        cli::offline::new_export(),
+        cli::offline::new_import(),
     ]
 });
 
@@ -159,6 +161,57 @@ For example, specifying 'email' is equivalent to 'match/email.yml'."#))
     .subcommand(SubCommand::with_name("launcher").setting(AppSettings::Hidden))
     .subcommand(SubCommand::with_name("log").about("Print the daemon logs."))
     .subcommand(
+      SubCommand::with_name("export")
+        .about("Export Espanso data as a base64 payload for offline transfer.")
+        .long_about("Export Espanso data as a base64 payload for offline transfer.\n\n\
+EXAMPLES:\n  \
+  espanso export > backup.txt\n  \
+  espanso export --scope config,matches > backup.txt\n  \
+  espanso export --scope packages > packages-only.txt\n  \
+  espanso export --wrap 76 > backup.txt")
+        .arg(
+          Arg::with_name("scope")
+            .long("scope")
+            .takes_value(true)
+            .help("Comma-separated list of scopes: config,matches,packages (default all)"),
+        )
+        .arg(
+          Arg::with_name("wrap")
+            .long("wrap")
+            .takes_value(true)
+            .help("Wrap base64 output at the given column width"),
+        ),
+    )
+    .subcommand(
+      SubCommand::with_name("import")
+        .about("Import Espanso data from a base64 payload for offline transfer.")
+        .long_about("Import Espanso data from a base64 payload for offline transfer.\n\n\
+EXAMPLES:\n  \
+  espanso import < backup.txt\n  \
+  espanso import --scope config < config-only.txt\n  \
+  espanso import --yes < backup.txt\n  \
+  espanso import --convert-lb < backup.txt\n  \
+  cat backup.txt | espanso import --yes")
+        .arg(
+          Arg::with_name("scope")
+            .long("scope")
+            .takes_value(true)
+            .help("Comma-separated list of scopes: config,matches,packages (default all)"),
+        )
+        .arg(
+          Arg::with_name("yes")
+            .long("yes")
+            .takes_value(false)
+            .help("Skip confirmation prompt"),
+        )
+        .arg(
+          Arg::with_name("convert-lb")
+            .long("convert-lb")
+            .takes_value(false)
+            .help("Convert line breaks to LF for YAML files (.yml/.yaml) during import"),
+        ),
+    )
+    .subcommand(
       SubCommand::with_name("stats")
         .about("Show expansion statistics")
         .arg(
@@ -235,6 +288,35 @@ For example, specifying 'email' is equivalent to 'match/email.yml'."#))
                 .required(false)
                 .takes_value(false)
                 .help("Interpret the input data as JSON"),
+            ),
+        )
+        .subcommand(
+          SubCommand::with_name("export_dialog")
+            .about("Display the Export Dialog")
+            .arg(
+              Arg::with_name("runtime_path")
+                .long("runtime-path")
+                .required(true)
+                .takes_value(true)
+                .help("Path to runtime directory"),
+            )
+            .arg(
+              Arg::with_name("config_path")
+                .long("config-path")
+                .required(true)
+                .takes_value(true)
+                .help("Path to config directory"),
+            ),
+        )
+        .subcommand(
+          SubCommand::with_name("import_dialog")
+            .about("Display the Import Dialog")
+            .arg(
+              Arg::with_name("config_path")
+                .long("config-path")
+                .required(true)
+                .takes_value(true)
+                .help("Path to config directory"),
             ),
         )
         .subcommand(

--- a/espanso/src/path/macos.rs
+++ b/espanso/src/path/macos.rs
@@ -22,7 +22,7 @@ use std::{fs::create_dir_all, io::ErrorKind};
 use thiserror::Error;
 
 use anyhow::{bail, Context, Result};
-use log::{debug, error, warn};
+use log::{debug, warn};
 
 pub fn is_espanso_in_path() -> bool {
     PathBuf::from("/usr/local/bin/espanso").is_file()


### PR DESCRIPTION
Implements offline export/import commands with scope filtering, secure extraction, optional YAML line-break conversion, and restart integration. Adds deps and tests, plus brief docs.