### PR TITLE
CI: upload build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
           cargo build \
             --no-default-features \
             --features modulo,vendored-tls
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: espanso-linux-x11
+          path: target/debug/espanso
       - name: Test
         run: |
           cargo test \
@@ -105,6 +110,11 @@ jobs:
           cargo build \
             --no-default-features \
             --features modulo,vendored-tls,wayland
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: espanso-linux-wayland
+          path: target/debug/espanso
       - name: Test
         run: |
           cargo test \
@@ -139,6 +149,13 @@ jobs:
           cargo build --target aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
           cargo build --target x86_64-apple-darwin
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: espanso-macos
+          path: |
+            target/aarch64-apple-darwin/debug/espanso
+            target/x86_64-apple-darwin/debug/espanso
       - name: Clippy
         run: |
           cargo clippy --target=aarch64-apple-darwin -- --deny warnings
@@ -160,5 +177,10 @@ jobs:
       - name: Build
         run: |
           cargo build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: espanso-windows
+          path: target/debug/espanso.exe
       - name: Clippy
         run: cargo clippy -- --deny warnings

--- a/espanso-clipboard/src/cocoa/mod.rs
+++ b/espanso-clipboard/src/cocoa/mod.rs
@@ -26,7 +26,6 @@ use std::{
 
 use crate::{Clipboard, ClipboardOperationOptions};
 use anyhow::Result;
-use log::error;
 use std::os::raw::c_char;
 use thiserror::Error;
 

--- a/espanso-clipboard/src/win32/mod.rs
+++ b/espanso-clipboard/src/win32/mod.rs
@@ -23,7 +23,6 @@ use std::{ffi::CString, path::PathBuf};
 
 use crate::{Clipboard, ClipboardOperationOptions};
 use anyhow::Result;
-use log::error;
 use thiserror::Error;
 use widestring::{U16CStr, U16CString};
 

--- a/espanso-inject/src/evdev/mod.rs
+++ b/espanso-inject/src/evdev/mod.rs
@@ -31,7 +31,7 @@ use std::{
 
 use context::Context;
 use keymap::Keymap;
-use log::{error, warn};
+use log::warn;
 use uinput::UInputDevice;
 
 use crate::{

--- a/espanso-inject/src/mac/mod.rs
+++ b/espanso-inject/src/mac/mod.rs
@@ -21,7 +21,6 @@ mod raw_keys;
 
 use std::{ffi::CString, os::raw::c_char};
 
-use log::error;
 use raw_keys::convert_key_to_vkey;
 
 use anyhow::Result;

--- a/espanso-inject/src/win32/mod.rs
+++ b/espanso-inject/src/win32/mod.rs
@@ -19,7 +19,6 @@
 
 mod raw_keys;
 
-use log::error;
 use raw_keys::convert_key_to_vkey;
 
 use anyhow::Result;

--- a/espanso-inject/src/x11/default/mod.rs
+++ b/espanso-inject/src/x11/default/mod.rs
@@ -30,7 +30,7 @@ use crate::x11::ffi::{
     XSendEvent, XSync, XTestFakeKeyEvent,
 };
 use libc::c_void;
-use log::{debug, error};
+use log::debug;
 
 use crate::{linux::raw_keys::convert_to_sym_array, x11::ffi::Xutf8LookupString};
 use anyhow::{bail, Result};

--- a/espanso-render/src/extension/choice.rs
+++ b/espanso-render/src/extension/choice.rs
@@ -18,7 +18,6 @@
  */
 
 use anyhow::Result;
-use log::error;
 use thiserror::Error;
 
 use crate::{Extension, ExtensionOutput, ExtensionResult, Params, Value};

--- a/espanso-render/src/extension/form.rs
+++ b/espanso-render/src/extension/form.rs
@@ -17,7 +17,6 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use log::error;
 use std::{collections::HashMap, sync::LazyLock};
 use thiserror::Error;
 

--- a/espanso/src/cli/service/macos.rs
+++ b/espanso/src/cli/service/macos.rs
@@ -18,7 +18,7 @@
  */
 
 use anyhow::{bail, Result};
-use log::{error, info, warn};
+use log::{info, warn};
 use std::process::Command;
 use std::{fs::create_dir_all, process::ExitStatus};
 use thiserror::Error;

--- a/espanso/src/path/macos.rs
+++ b/espanso/src/path/macos.rs
@@ -22,7 +22,7 @@ use std::{fs::create_dir_all, io::ErrorKind};
 use thiserror::Error;
 
 use anyhow::{bail, Context, Result};
-use log::{debug, error, warn};
+use log::{debug, warn};
 
 pub fn is_espanso_in_path() -> bool {
     PathBuf::from("/usr/local/bin/espanso").is_file()


### PR DESCRIPTION
Uploads build artifacts for linux, macOS (both arches), and Windows jobs so binaries are downloadable from CI runs.