### PR TITLE
feat: Redesigned 'espanso expand' command for text rendering

### DIFF
--- a/espanso/src/cli/expand.rs
+++ b/espanso/src/cli/expand.rs
@@ -1,0 +1,361 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::io::{self, IsTerminal, Read};
+
+use anyhow::{bail, Context, Result};
+use espanso_config::{
+    config::AppProperties,
+    matches::{Match, MatchCause, MatchEffect, UpperCasingStyle},
+};
+use espanso_render::Renderer;
+use espanso_render::{CasingStyle, Context as RenderContext, RenderOptions, Template, Variable};
+
+use super::{CliModule, CliModuleArgs};
+
+pub fn new() -> CliModule {
+    CliModule {
+        requires_paths: true,
+        requires_config: true,
+        subcommand: "expand".to_string(),
+        entry: expand_main,
+        ..Default::default()
+    }
+}
+
+fn expand_main(args: CliModuleArgs) -> i32 {
+    match expand_main_result(args) {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("ERROR: {err:#}");
+            1
+        }
+    }
+}
+
+fn expand_main_result(args: CliModuleArgs) -> Result<()> {
+    let cli_args = args.cli_args.expect("missing cli_args");
+    let config_store = args.config_store.expect("missing config_store");
+    let match_store = args.match_store.expect("missing match_store");
+    let paths = args.paths.expect("missing paths");
+
+    // Get input text with priority: stdin > file > argument
+    let input_text = get_input_text(&cli_args)?;
+
+    if input_text.is_empty() {
+        bail!("no input text provided. Use: stdin pipe, -f/--file, or text argument");
+    }
+
+    // Get optional context filters
+    let class = cli_args.value_of("class");
+    let title = cli_args.value_of("title");
+    let exec = cli_args.value_of("exec");
+
+    let config = config_store.active(&AppProperties { title, class, exec });
+    let match_set = match_store.query(config.match_paths());
+
+    // Build trigger map for efficient lookup
+    let trigger_map: Vec<(&str, &Match)> = match_set
+        .matches
+        .iter()
+        .flat_map(|m| {
+            if let MatchCause::Trigger(cause) = &m.cause {
+                cause
+                    .triggers
+                    .iter()
+                    .map(|t| (t.as_str(), *m))
+                    .collect::<Vec<_>>()
+            } else {
+                vec![]
+            }
+        })
+        .collect();
+
+    // Sort by trigger length (longest first) to match longer triggers before shorter ones
+    let mut sorted_triggers: Vec<(&str, &Match)> = trigger_map;
+    sorted_triggers.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+
+    // Build templates for rendering
+    let templates: Vec<Template> = match_set
+        .matches
+        .iter()
+        .filter_map(|m| convert_to_template(m))
+        .collect();
+    let template_refs: Vec<&Template> = templates.iter().collect();
+
+    let global_vars: Vec<Variable> = match_set
+        .global_vars
+        .iter()
+        .copied()
+        .map(convert_var)
+        .collect();
+    let global_var_refs: Vec<&Variable> = global_vars.iter().collect();
+
+    let context = RenderContext {
+        global_vars: global_var_refs,
+        templates: template_refs,
+    };
+
+    // Create renderer with all extensions
+    let locale_provider = espanso_render::extension::date::DefaultLocaleProvider::new();
+    let date_extension = espanso_render::extension::date::DateExtension::new(&locale_provider);
+    let echo_extension = espanso_render::extension::echo::EchoExtension::new();
+    let random_extension = espanso_render::extension::random::RandomExtension::new();
+    let home_path = dirs::home_dir().context("unable to obtain home dir path")?;
+    let script_extension = espanso_render::extension::script::ScriptExtension::new(
+        &paths.config,
+        &home_path,
+        &paths.packages,
+    );
+    let shell_extension = espanso_render::extension::shell::ShellExtension::new(&paths.config);
+    let renderer = espanso_render::create(vec![
+        &date_extension,
+        &echo_extension,
+        &random_extension,
+        &script_extension,
+        &shell_extension,
+    ]);
+
+    // Process input text and replace triggers
+    let output = expand_triggers(&input_text, &sorted_triggers, &renderer, &context)?;
+
+    print!("{output}");
+
+    Ok(())
+}
+
+fn get_input_text(cli_args: &clap::ArgMatches) -> Result<String> {
+    // Priority 1: stdin (if not a terminal)
+    if !io::stdin().is_terminal() {
+        let mut buffer = String::new();
+        io::stdin()
+            .read_to_string(&mut buffer)
+            .context("failed to read from stdin")?;
+        return Ok(buffer);
+    }
+
+    // Priority 2: file
+    if let Some(file_path) = cli_args.value_of("file") {
+        let content = std::fs::read_to_string(file_path)
+            .context(format!("failed to read file: {file_path}"))?;
+        return Ok(content);
+    }
+
+    // Priority 3: text argument
+    if let Some(values) = cli_args.values_of("text") {
+        let text: Vec<&str> = values.collect();
+        // Process escape sequences like \n
+        let joined = text.join(" ");
+        let processed = process_escape_sequences(&joined);
+        return Ok(processed);
+    }
+
+    Ok(String::new())
+}
+
+fn process_escape_sequences(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.peek() {
+                Some('n') => {
+                    result.push('\n');
+                    chars.next();
+                }
+                Some('t') => {
+                    result.push('\t');
+                    chars.next();
+                }
+                Some('r') => {
+                    result.push('\r');
+                    chars.next();
+                }
+                Some('\\') => {
+                    result.push('\\');
+                    chars.next();
+                }
+                _ => result.push(c),
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+fn expand_triggers(
+    input: &str,
+    triggers: &[(&str, &Match)],
+    renderer: &impl Renderer,
+    context: &RenderContext,
+) -> Result<String> {
+    let mut result = input.to_string();
+
+    // Keep expanding until no more triggers are found (handles nested triggers)
+    let mut changed = true;
+    let mut iterations = 0;
+    const MAX_ITERATIONS: usize = 100; // Prevent infinite loops
+
+    while changed && iterations < MAX_ITERATIONS {
+        changed = false;
+        iterations += 1;
+
+        for (trigger, match_ref) in triggers {
+            if result.contains(*trigger) {
+                if let Some(template) = convert_to_template(match_ref) {
+                    let options = RenderOptions {
+                        casing_style: calculate_casing_style(match_ref, trigger),
+                    };
+
+                    let rendered = match renderer.render(&template, context, &options) {
+                        espanso_render::RenderResult::Success(body) => body,
+                        espanso_render::RenderResult::Aborted => continue,
+                        espanso_render::RenderResult::Error(err) => {
+                            return Err(err.context(format!("failed to render trigger '{trigger}'")))
+                        }
+                    };
+
+                    result = result.replace(*trigger, &rendered);
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    if iterations >= MAX_ITERATIONS {
+        eprintln!("WARNING: max iterations reached, possible circular trigger reference");
+    }
+
+    Ok(result)
+}
+
+fn convert_to_template(m: &Match) -> Option<Template> {
+    if let MatchEffect::Text(text_effect) = &m.effect {
+        let ids = if let MatchCause::Trigger(cause) = &m.cause {
+            cause.triggers.clone()
+        } else {
+            Vec::new()
+        };
+
+        Some(Template {
+            ids,
+            body: text_effect.replace.clone(),
+            vars: text_effect.vars.iter().map(convert_var).collect(),
+        })
+    } else {
+        None
+    }
+}
+
+fn convert_var(var: &espanso_config::matches::Variable) -> espanso_render::Variable {
+    Variable {
+        name: var.name.clone(),
+        var_type: var.var_type.clone(),
+        params: convert_params(var.params.clone()),
+        inject_vars: var.inject_vars,
+        depends_on: var.depends_on.clone(),
+    }
+}
+
+fn convert_params(params: espanso_config::matches::Params) -> espanso_render::Params {
+    let mut new_params = espanso_render::Params::new();
+    for (key, value) in params {
+        new_params.insert(key, convert_value(value));
+    }
+    new_params
+}
+
+fn convert_value(value: espanso_config::matches::Value) -> espanso_render::Value {
+    match value {
+        espanso_config::matches::Value::Null => espanso_render::Value::Null,
+        espanso_config::matches::Value::Bool(v) => espanso_render::Value::Bool(v),
+        espanso_config::matches::Value::Number(n) => match n {
+            espanso_config::matches::Number::Integer(i) => {
+                espanso_render::Value::Number(espanso_render::Number::Integer(i))
+            }
+            espanso_config::matches::Number::Float(f) => {
+                espanso_render::Value::Number(espanso_render::Number::Float(f.into_inner()))
+            }
+        },
+        espanso_config::matches::Value::String(s) => espanso_render::Value::String(s),
+        espanso_config::matches::Value::Array(v) => {
+            espanso_render::Value::Array(v.into_iter().map(convert_value).collect())
+        }
+        espanso_config::matches::Value::Object(params) => {
+            espanso_render::Value::Object(convert_params(params))
+        }
+    }
+}
+
+fn calculate_casing_style(m: &Match, trigger: &str) -> CasingStyle {
+    let MatchCause::Trigger(cause) = &m.cause else {
+        return CasingStyle::None;
+    };
+
+    if !cause.propagate_case {
+        return CasingStyle::None;
+    }
+
+    let mut first_alphabetic = None;
+    let mut second_alphabetic = None;
+
+    for c in trigger.chars() {
+        if c.is_alphabetic() {
+            if first_alphabetic.is_none() {
+                first_alphabetic = Some(c);
+            } else if second_alphabetic.is_none() {
+                second_alphabetic = Some(c);
+            } else {
+                break;
+            }
+        }
+    }
+
+    match (first_alphabetic, second_alphabetic) {
+        (Some(first), Some(second)) => {
+            if first.is_uppercase() {
+                if second.is_uppercase() {
+                    CasingStyle::Uppercase
+                } else {
+                    match cause.uppercase_style {
+                        UpperCasingStyle::CapitalizeWords => CasingStyle::CapitalizeWords,
+                        _ => CasingStyle::Capitalize,
+                    }
+                }
+            } else {
+                CasingStyle::None
+            }
+        }
+        (Some(first), None) => {
+            if first.is_uppercase() {
+                match cause.uppercase_style {
+                    UpperCasingStyle::Capitalize => CasingStyle::Capitalize,
+                    UpperCasingStyle::CapitalizeWords => CasingStyle::CapitalizeWords,
+                    _ => CasingStyle::Uppercase,
+                }
+            } else {
+                CasingStyle::None
+            }
+        }
+        _ => CasingStyle::None,
+    }
+}

--- a/espanso/src/cli/mod.rs
+++ b/espanso/src/cli/mod.rs
@@ -28,6 +28,7 @@ pub mod daemon;
 pub mod doctor;
 pub mod edit;
 pub mod env_path;
+pub mod expand;
 pub mod launcher;
 pub mod log;
 pub mod match_cli;

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -64,6 +64,7 @@ static CLI_HANDLERS: LazyLock<Vec<CliModule>> = LazyLock::new(|| {
         cli::path::new(),
         cli::edit::new(),
         cli::doctor::new(),
+        cli::expand::new(),
         cli::launcher::new(),
         cli::log::new(),
         cli::stats::new(),
@@ -229,6 +230,40 @@ EXAMPLES:\n  \
             .takes_value(false)
             .help("Convert line breaks to LF for YAML files (.yml/.yaml) during import"),
         ),
+    )
+    .subcommand(
+      SubCommand::with_name("expand")
+        .about("Expand triggers in text and print the result. Input priority: stdin > file > argument.")
+        .arg(
+          Arg::with_name("text")
+            .multiple(true)
+            .help("Text containing triggers to expand (lowest priority)"),
+        )
+        .arg(
+          Arg::with_name("file")
+            .short('f')
+            .long("file")
+            .takes_value(true)
+            .help("Read input text from file"),
+        )
+        .arg(
+          Arg::with_name("class")
+            .long("class")
+            .takes_value(true)
+            .help("Simulate app class for context-aware matching"),
+        )
+        .arg(
+          Arg::with_name("title")
+            .long("title")
+            .takes_value(true)
+            .help("Simulate app title for context-aware matching"),
+        )
+        .arg(
+          Arg::with_name("exec")
+            .long("exec")
+            .takes_value(true)
+            .help("Simulate app executable for context-aware matching"),
+        )
     )
     .subcommand(
       SubCommand::with_name("stats")


### PR DESCRIPTION
## Summary

This PR replaces the old `espanso expand --dry-run <trigger>` command with a more flexible and useful text rendering tool.

## Motivation

The previous implementation had several design issues:
- The `--dry-run` flag was mandatory (making it pointless)
- It only accepted a single trigger, not arbitrary text
- The naming was confusing - "dry-run" implies nothing happens, but expansion IS executed
- Limited utility - you could just type the trigger in a text editor to see the expansion

## New Design

The redesigned command processes input text containing triggers and outputs the fully expanded result.

### Input Methods (Priority Order)

1. **Via stdin pipe** (highest priority)
   ```bash
   echo "Current date: :date, time: :time" | espanso expand
   cat template.txt | espanso expand
   ```

2. **Via file** (second priority)
   ```bash
   espanso expand -f template.txt
   espanso expand --file /path/to/template.txt
   ```

3. **Via command argument** (lowest priority)
   ```bash
   espanso expand "Hello :name, today is :date"
   espanso expand 'Signature:\n:sig'
   ```

### Options

| Option | Description |
|--------|-------------|
| `-f, --file <FILE>` | Read input text from file |
| `--class <CLASS>` | Simulate app class for context-aware matching |
| `--title <TITLE>` | Simulate app title for context-aware matching |
| `--exec <EXEC>` | Simulate app executable for context-aware matching |

## Features

- Expands all triggers found in input text (not just a single trigger)
- Supports context simulation for app-specific matches
- Handles nested trigger expansion with loop protection (max 100 iterations)
- Processes escape sequences (`\n`, `\t`, `\r`, `\\`) in text arguments
- Evaluates all variables and extensions (date, shell, script, random, echo)
- Longer triggers matched first to handle overlapping trigger patterns

## Use Cases

### Template Rendering
```bash
espanso expand -f email_template.txt > rendered_email.txt
cat invoice.md | espanso expand | pandoc -o invoice.pdf
```

### Dynamic Script Output
```bash
MESSAGE=$(echo "Report generated on :date at :time" | espanso expand)
echo "$MESSAGE"
```

### Quick Expansion Check
```bash
espanso expand ":sig"
espanso expand "Email: :email Phone: :phone"
```

### Context-Aware Expansion
```bash
espanso expand --class "Code" ":snippet"
espanso expand --exec "slack" ":reaction"
```

## Test Plan

- [ ] Test stdin input: `echo "test :date" | espanso expand`
- [ ] Test file input: `espanso expand -f test.txt`
- [ ] Test argument input: `espanso expand "test :date"`
- [ ] Test priority (stdin over file over argument)
- [ ] Test context flags work correctly
- [ ] Test escape sequence processing
- [ ] Test nested trigger expansion
- [ ] Test error handling (missing file, empty input)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)