### PR TITLE
feat: add configurable toggle_key_press_count option

### DIFF
--- a/espanso-config/src/config/mod.rs
+++ b/espanso-config/src/config/mod.rs
@@ -86,6 +86,12 @@ pub trait Config: Send + Sync {
     // Defines the key that disables/enables espanso when double pressed
     fn toggle_key(&self) -> Option<ToggleKey>;
 
+    // Number of times the toggle key must be pressed to toggle espanso.
+    // Defaults to 2 (double press).
+    fn toggle_key_press_count(&self) -> u32 {
+        2
+    }
+
     // If true, instructs the daemon process to restart the worker (and refresh
     // the configuration) after a configuration file change is detected on disk.
     fn auto_restart(&self) -> bool;
@@ -227,6 +233,7 @@ pub trait Config: Send + Sync {
         pre_paste_delay: {}
         paste_shortcut_event_delay: {}
         toggle_key: {:?}
+        toggle_key_press_count: {:?}
         auto_restart: {:?}
         restore_clipboard_delay: {:?}
         post_form_delay: {:?}
@@ -266,6 +273,7 @@ pub trait Config: Send + Sync {
           self.pre_paste_delay(),
           self.paste_shortcut_event_delay(),
           self.toggle_key(),
+          self.toggle_key_press_count(),
           self.auto_restart(),
           self.restore_clipboard_delay(),
           self.post_form_delay(),

--- a/espanso-config/src/config/parse/mod.rs
+++ b/espanso-config/src/config/parse/mod.rs
@@ -33,6 +33,7 @@ pub struct ParsedConfig {
     pub auto_restart: Option<bool>,
     pub preserve_clipboard: Option<bool>,
     pub toggle_key: Option<String>,
+    pub toggle_key_press_count: Option<u32>,
     pub paste_shortcut: Option<String>,
     pub disable_x11_fast_inject: Option<bool>,
     pub word_separators: Option<Vec<String>>,

--- a/espanso-config/src/config/parse/yaml.rs
+++ b/espanso-config/src/config/parse/yaml.rs
@@ -53,6 +53,9 @@ pub struct YAMLConfig {
     pub toggle_key: Option<String>,
 
     #[serde(default)]
+    pub toggle_key_press_count: Option<u32>,
+
+    #[serde(default)]
     pub auto_restart: Option<bool>,
 
     #[serde(default)]
@@ -203,6 +206,7 @@ impl TryFrom<YAMLConfig> for ParsedConfig {
             clipboard_threshold: yaml_config.clipboard_threshold,
             auto_restart: yaml_config.auto_restart,
             toggle_key: yaml_config.toggle_key,
+            toggle_key_press_count: yaml_config.toggle_key_press_count,
             preserve_clipboard: yaml_config.preserve_clipboard,
             paste_shortcut: yaml_config.paste_shortcut,
             disable_x11_fast_inject: yaml_config.disable_x11_fast_inject,
@@ -281,6 +285,7 @@ mod tests {
     clipboard_threshold: 200
     pre_paste_delay: 300
     toggle_key: CTRL
+    toggle_key_press_count: 3
     auto_restart: false
     preserve_clipboard: false
     restore_clipboard_delay: 400
@@ -383,6 +388,7 @@ mod tests {
                 evdev_modifier_delay: Some(40),
 
                 toggle_key: Some("CTRL".to_string()),
+                toggle_key_press_count: Some(3),
                 word_separators: Some(vec!["'".to_owned(), ".".to_owned()]),
 
                 use_standard_includes: Some(true),

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -192,6 +192,10 @@ impl Config for ResolvedConfig {
         }
     }
 
+    fn toggle_key_press_count(&self) -> u32 {
+        self.parsed.toggle_key_press_count.unwrap_or(2)
+    }
+
     fn preserve_clipboard(&self) -> bool {
         self.parsed.preserve_clipboard.unwrap_or(true)
     }
@@ -433,6 +437,7 @@ impl ResolvedConfig {
             paste_shortcut_event_delay,
             disable_x11_fast_inject,
             toggle_key,
+            toggle_key_press_count,
             inject_delay,
             key_delay,
             evdev_modifier_delay,

--- a/espanso-engine/src/process/middleware/disable.rs
+++ b/espanso-engine/src/process/middleware/disable.rs
@@ -34,12 +34,14 @@ pub struct DisableOptions {
     pub toggle_key: Option<Key>,
     pub toggle_key_variant: Option<Variant>,
     pub toggle_key_maximum_window: Duration,
+    pub toggle_key_press_count: u32,
     // TODO: toggle shortcut?
 }
 
 pub struct DisableMiddleware {
     enabled: RefCell<bool>,
     last_toggle_press: RefCell<Option<Instant>>,
+    toggle_press_count: RefCell<u32>,
     options: DisableOptions,
 }
 
@@ -48,6 +50,7 @@ impl DisableMiddleware {
         Self {
             enabled: RefCell::new(true),
             last_toggle_press: RefCell::new(None),
+            toggle_press_count: RefCell::new(0),
             options,
         }
     }
@@ -66,22 +69,30 @@ impl Middleware for DisableMiddleware {
             EventType::Keyboard(m_event) => {
                 if m_event.status == Status::Released {
                     let mut last_toggle_press = self.last_toggle_press.borrow_mut();
+                    let mut toggle_press_count = self.toggle_press_count.borrow_mut();
                     if is_toggle_key(m_event, &self.options) {
-                        if let Some(previous_press) = *last_toggle_press {
-                            if previous_press.elapsed() < self.options.toggle_key_maximum_window {
-                                *enabled = !*enabled;
-                                *last_toggle_press = None;
-                                has_status_changed = true;
-                            } else {
-                                *last_toggle_press = Some(Instant::now());
-                            }
+                        let within_window = last_toggle_press
+                            .map(|t| t.elapsed() < self.options.toggle_key_maximum_window)
+                            .unwrap_or(false);
+
+                        if within_window {
+                            *toggle_press_count += 1;
                         } else {
-                            *last_toggle_press = Some(Instant::now());
+                            *toggle_press_count = 1;
+                        }
+                        *last_toggle_press = Some(Instant::now());
+
+                        if *toggle_press_count >= self.options.toggle_key_press_count {
+                            *enabled = !*enabled;
+                            *last_toggle_press = None;
+                            *toggle_press_count = 0;
+                            has_status_changed = true;
                         }
                     } else {
                         // If another key is pressed (not the toggle key), we should reset the window
                         // For more information, see: https://github.com/espanso/espanso/issues/815
                         *last_toggle_press = None;
+                        *toggle_press_count = 0;
                     }
                 }
             }

--- a/espanso/src/cli/worker/engine/process/middleware/disable.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/disable.rs
@@ -54,5 +54,6 @@ pub fn extract_disable_options(config: &dyn Config) -> DisableOptions {
         toggle_key,
         toggle_key_variant: variant,
         toggle_key_maximum_window: Duration::from_millis(1000),
+        toggle_key_press_count: config.toggle_key_press_count(),
     }
 }

--- a/espanso/src/patch/patches/mod.rs
+++ b/espanso/src/patch/patches/mod.rs
@@ -38,6 +38,7 @@ generate_patchable_config!(
   paste_shortcut -> Option<String>,
   disable_x11_fast_inject -> bool,
   toggle_key -> Option<ToggleKey>,
+  toggle_key_press_count -> u32,
   auto_restart -> bool,
   preserve_clipboard -> bool,
   restore_clipboard_delay -> usize,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -104,7 +104,7 @@
       "type": "boolean"
     },
     "toggle_key": {
-      "description": "Defines the key that disables/enables espanso when double pressed.",
+      "description": "Defines the key that disables/enables espanso when pressed multiple times.",
       "type": "string",
       "enum": [
         "OFF",
@@ -121,6 +121,12 @@
         "RIGHT_SHIFT",
         "RIGHT_META"
       ]
+    },
+    "toggle_key_press_count": {
+      "description": "Number of times the toggle key must be pressed to toggle espanso. Defaults to 2 (double press).",
+      "type": "integer",
+      "minimum": 1,
+      "default": 2
     },
     "win32_exclude_orphan_events": {
       "description": "If true, filter out keyboard events without an explicit HID device source on Windows. This is needed to filter out the software-generated events, including those from Espanso, but might need to be disabled when using some software-level keyboards. Disabling this option might conflict with the undo feature.",


### PR DESCRIPTION
## Summary

- Add a new configuration option `toggle_key_press_count` that allows users to specify how many consecutive presses of the toggle key are required to toggle espanso
- Previously hardcoded to 2 presses (double-press), now configurable
- Defaults to 2 for backward compatibility

## Changes

- Added `toggle_key_press_count` field to config parsing (YAML and structs)
- Added `toggle_key_press_count()` method to Config trait
- Modified DisableMiddleware to track press count instead of just last press
- Updated JSON schema with new option

## Example Configuration

```yaml
toggle_key: ALT
toggle_key_press_count: 3  # Require triple-press to toggle
```

## Test plan

- [ ] Verify default behavior (2 presses) still works
- [ ] Test with `toggle_key_press_count: 1` for single-press toggle
- [ ] Test with `toggle_key_press_count: 3` for triple-press toggle
- [ ] Verify window timeout still resets the counter correctly
- [ ] Verify pressing other keys resets the counter

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)